### PR TITLE
Add `NeutralLogarithmicStabilityProfile`

### DIFF
--- a/src/OceanSeaIceModels/CrossRealmFluxes/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/CrossRealmFluxes/similarity_theory_turbulent_fluxes.jl
@@ -217,16 +217,12 @@ the Monin-Obukhov length ``L`` and the roughness length ``ℓ``.
 """
 struct LogarithmicSimilarityProfile end
 struct COARELogarithmicSimilarityProfile end
-struct NeutralLogarithmicSimilarityProfile end
 
 @inline similarity_profile(::LogarithmicSimilarityProfile, ψ, h, ℓ, L) =
     log(h / ℓ) - ψ(h / L) + ψ(ℓ / L)
 
 @inline similarity_profile(::COARELogarithmicSimilarityProfile, ψ, h, ℓ, L) =
     log(h / ℓ) - ψ(h / L)
-
-@inline similarity_profile(::NeutralLogarithmicSimilarityProfile, ψ, h, ℓ, L) =
-    log(h / ℓ) 
 
 #####
 ##### Fixed-point iteration for roughness length

--- a/src/OceanSeaIceModels/CrossRealmFluxes/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/CrossRealmFluxes/similarity_theory_turbulent_fluxes.jl
@@ -217,11 +217,15 @@ the Monin-Obukhov length ``L`` and the roughness length ``ℓ``.
 """
 struct LogarithmicSimilarityProfile end
 struct COARELogarithmicSimilarityProfile end
+struct NeutralLogarithmicSimilarityProfile end
 
 @inline similarity_profile(::LogarithmicSimilarityProfile, ψ, h, ℓ, L) =
     log(h / ℓ) - ψ(h / L) + ψ(ℓ / L)
 
 @inline similarity_profile(::COARELogarithmicSimilarityProfile, ψ, h, ℓ, L) =
+    log(h / ℓ) - ψ(h / L)
+
+@inline similarity_profile(::NeutralLogarithmicSimilarityProfile, ψ, h, ℓ, L) =
     log(h / ℓ) - ψ(h / L)
 
 #####

--- a/src/OceanSeaIceModels/CrossRealmFluxes/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/CrossRealmFluxes/similarity_theory_turbulent_fluxes.jl
@@ -226,7 +226,7 @@ struct NeutralLogarithmicSimilarityProfile end
     log(h / ℓ) - ψ(h / L)
 
 @inline similarity_profile(::NeutralLogarithmicSimilarityProfile, ψ, h, ℓ, L) =
-    log(h / ℓ) - ψ(h / L)
+    log(h / ℓ) 
 
 #####
 ##### Fixed-point iteration for roughness length

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -4,7 +4,8 @@ using ClimaOcean.OceanSeaIceModels.CrossRealmFluxes:
                                     celsius_to_kelvin, 
                                     convert_to_kelvin, 
                                     SimilarityScales,
-                                    seawater_saturation_specific_humidity
+                                    seawater_saturation_specific_humidity,
+                                    NeutralLogarithmicSimilarityProfile
 
 using Thermodynamics
 import ClimaOcean.OceanSeaIceModels.CrossRealmFluxes: water_saturation_specific_humidity
@@ -80,16 +81,13 @@ end
     # the atmosphere, have zero gustiness and a constant roughness length of
     # `1e-4` for momentum, water vapor and temperature
     # For this case we can compute the fluxes by hand.
-
-    @inline neutral_bulk_coefficients(ψ, h, ℓ, L) = log(h / ℓ)
-
     ℓ = 1e-4
 
     roughness_lengths = SimilarityScales(ℓ, ℓ, ℓ)
     similarity_theory = SimilarityTheoryTurbulentFluxes(grid; 
                                                         roughness_lengths, 
                                                         gustiness_parameter = 0,
-                                                        bulk_coefficients = neutral_bulk_coefficients)
+                                                        similarity_profile_type = NeutralLogarithmicSimilarityProfile())
 
     # mid-latitude ocean conditions
     set!(ocean.model, u = 0, v = 0, T = 15, S = 30)

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -4,8 +4,7 @@ using ClimaOcean.OceanSeaIceModels.CrossRealmFluxes:
                                     celsius_to_kelvin, 
                                     convert_to_kelvin, 
                                     SimilarityScales,
-                                    seawater_saturation_specific_humidity,
-                                    NeutralLogarithmicSimilarityProfile
+                                    seawater_saturation_specific_humidity
 
 using Thermodynamics
 import ClimaOcean.OceanSeaIceModels.CrossRealmFluxes: water_saturation_specific_humidity
@@ -82,12 +81,18 @@ end
     # `1e-4` for momentum, water vapor and temperature
     # For this case we can compute the fluxes by hand.
     ℓ = 1e-4
+    
+    @inline zero_stability_function(ζ) = zero(ζ)
+
+    stability_functions = SimilarityScales(zero_stability_function, 
+                                           zero_stability_function, 
+                                           zero_stability_function)
 
     roughness_lengths = SimilarityScales(ℓ, ℓ, ℓ)
     similarity_theory = SimilarityTheoryTurbulentFluxes(grid; 
                                                         roughness_lengths, 
                                                         gustiness_parameter = 0,
-                                                        similarity_profile_type = NeutralLogarithmicSimilarityProfile())
+                                                        stability_functions)
 
     # mid-latitude ocean conditions
     set!(ocean.model, u = 0, v = 0, T = 15, S = 30)


### PR DESCRIPTION
This addition is motivated by the tests, but it might also be usefull in the future for testing or retrieving the neutral stability profile

closes #111 (hopefully)