### PR TITLE
Add biogeochemical interface to ocean_simulation

### DIFF
--- a/src/OceanSimulations/OceanSimulations.jl
+++ b/src/OceanSimulations/OceanSimulations.jl
@@ -106,7 +106,8 @@ function ocean_simulation(grid; Δt = 5minutes,
 
     if closure isa CATKEVerticalDiffusivity
         tracers = tuple(tracers..., :e)
-        tracer_advection = (; zip(tracers,tuple(fill(default_advection, length(tracers))...)))
+        advection_value = tuple(fill(tracer_advection, length(tracers))...)
+        tracer_advection = (; zip(tracers,advection_value)...)
         tracer_advection = merge(tracer_advection, (e = nothing,))
     end
 

--- a/src/OceanSimulations/OceanSimulations.jl
+++ b/src/OceanSimulations/OceanSimulations.jl
@@ -84,7 +84,9 @@ function ocean_simulation(grid; Δt = 5minutes,
                                  T = FieldBoundaryConditions(top = FluxBoundaryCondition(Jᵀ)),
                                  S = FieldBoundaryConditions(top = FluxBoundaryCondition(Jˢ)))
     
-    ocean_boundary_conditions = merge(ocean_boundary_conditions, boundary_conditions)    
+    if !isempty(boundary_conditions)
+        ocean_boundary_conditions = merge(ocean_boundary_conditions, boundary_conditions)    
+    end
 
     if grid isa ImmersedBoundaryGrid
         Fu = Forcing(u_immersed_bottom_drag, discrete_form=true, parameters=bottom_drag_coefficient)

--- a/src/OceanSimulations/OceanSimulations.jl
+++ b/src/OceanSimulations/OceanSimulations.jl
@@ -105,8 +105,8 @@ function ocean_simulation(grid; Δt = 5minutes,
 
 
     if closure isa CATKEVerticalDiffusivity
-        tracers = tuple(tracers..., :e) 
-        tracer_advection = NamedTuple{typeof(tracers)}((get(tracers, i, tracer_advection) for i in 1:length(tracers))...)
+        tracers = tuple(tracers..., :e)
+        tracer_advection = (; zip(tracers,tuple(fill(default_advection, length(tracers))...)))
         tracer_advection = merge(tracer_advection, (e = nothing,))
     end
 

--- a/src/OceanSimulations/OceanSimulations.jl
+++ b/src/OceanSimulations/OceanSimulations.jl
@@ -50,7 +50,6 @@ default_tracer_advection() = TracerAdvection(WENO(; order = 7),
 @inline u_immersed_bottom_drag(i, j, k, grid, clock, fields, μ) = @inbounds - μ * fields.u[i, j, k] * is_immersed_drag_u(i, j, k, grid) * spᶠᶜᶜ(i, j, k, grid, fields) / Δzᶠᶜᶜ(i, j, k, grid)
 @inline v_immersed_bottom_drag(i, j, k, grid, clock, fields, μ) = @inbounds - μ * fields.v[i, j, k] * is_immersed_drag_v(i, j, k, grid) * spᶜᶠᶜ(i, j, k, grid, fields) / Δzᶜᶠᶜ(i, j, k, grid)
 
-NoBiogeochemistry(args...; kwargs...) = nothing
 
 # TODO: Specify the grid to a grid on the sphere; otherwise we can provide a different
 # function that requires latitude and longitude etc for computing coriolis=FPlane...
@@ -65,7 +64,7 @@ function ocean_simulation(grid; Δt = 5minutes,
                           coriolis = HydrostaticSphericalCoriolis(; rotation_rate),
                           momentum_advection = default_momentum_advection(),
                           tracer_advection = default_tracer_advection(),
-                          biogeochemistry = NoBiogeochemistry,
+                          biogeochemistry = nothing,
                           tracers = (:T, :S),
                           boundary_conditions = NamedTuple(),
                           verbose = false)

--- a/src/OceanSimulations/OceanSimulations.jl
+++ b/src/OceanSimulations/OceanSimulations.jl
@@ -66,6 +66,7 @@ function ocean_simulation(grid; Δt = 5minutes,
                           momentum_advection = default_momentum_advection(),
                           tracer_advection = default_tracer_advection(),
                           biogeochemistry = NoBiogeochemistry,
+                          tracers = (:T, :S),
                           boundary_conditions = NamedTuple(),
                           verbose = false)
 
@@ -102,10 +103,11 @@ function ocean_simulation(grid; Δt = 5minutes,
         momentum_advection = nothing
     end
 
-    tracers = (:T, :S)
+
     if closure isa CATKEVerticalDiffusivity
-        tracers = tuple(tracers..., :e)
-        tracer_advection = (; T = tracer_advection, S = tracer_advection, e = nothing)
+        tracers = tuple(tracers..., :e) 
+        tracer_advection = NamedTuple{typeof(tracers)}((get(tracers, i, tracer_advection) for i in 1:length(tracers))...)
+        tracer_advection = merge(tracer_advection, (e = nothing,))
     end
 
     ocean_model = HydrostaticFreeSurfaceModel(; grid,

--- a/src/OceanSimulations/OceanSimulations.jl
+++ b/src/OceanSimulations/OceanSimulations.jl
@@ -119,6 +119,7 @@ function ocean_simulation(grid; Δt = 5minutes,
                                               free_surface,
                                               coriolis,
                                               forcing,
+                                              biogeochemistry,
                                               boundary_conditions = ocean_boundary_conditions)
 
     ocean = Simulation(ocean_model; Δt, verbose)


### PR DESCRIPTION
This PR addresses #107 by adding a `biogeochemistry` kwarg to `ocean_simulation`, adding user input `boundary_conditions` as a kwarg and moves `tracer` to be explicitly spelled out be the user as a kwarg.

Right now the user input `boundary_conditions` will be merged with hardcoded boundary conditions for T and S, unless the user supplies BCs for T and S in which case they will override the hardcoded ones. As @glwagner pointed out

> it would be nice if we only replace the boundary conditions we have to, ie we keep the surface fluxes of T, S even if we need to use user-supplied T or S conditions at the bottom or on immersed boundaries

but I haven't implemented that yet.


