### PR TITLE
Don't specify arch in github `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,11 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: '1.10'
+            run-name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
           - os: ubuntu-latest
             arch: x86
             version: '1.10'
+            run-name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -15,26 +15,13 @@ jobs:
           - '1.10'
         os:
           - ubuntu-latest
-        arch:
-          - x64
-          - x86
-        include:
-          # test macOS and Windows with latest Julia only
-          - os: macOS-latest
-            arch: x64
-            version: '1.10'
-          - os: windows-latest
-            arch: x64
-            version: '1.10'
-          - os: windows-latest
-            arch: x86
-            version: '1.10'
+          - macOS-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,10 +19,8 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x64
-            name: Julia 1.10 - ubuntu-latest - x64 - ${{ github.event_name }}
           - os: ubuntu-latest
             arch: x86
-            name: Julia 1.10 - ubuntu-latest - x86 - ${{ github.event_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,9 @@ jobs:
           - os: ubuntu-latest
             arch: x64
             version: '1.10'
-            run-name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
           - os: ubuntu-latest
             arch: x86
             version: '1.10'
-            run-name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,15 @@ jobs:
         version:
           - '1.10'
         os:
-          - ubuntu-latest
           - macOS-latest
           - windows-latest
+        include:
+          - os: ubuntu-latest
+            arch: x64
+            name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+          - os: ubuntu-latest
+            arch: x86
+            name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,8 +19,10 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x64
+            version: '1.10'
           - os: ubuntu-latest
             arch: x86
+            version: '1.10'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: x64
-            name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+            name: Julia 1.10 - ubuntu-latest - x64 - ${{ github.event_name }}
           - os: ubuntu-latest
             arch: x86
-            name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+            name: Julia 1.10 - ubuntu-latest - x86 - ${{ github.event_name }}
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -14,11 +14,13 @@ jobs:
         version:
           - '1.10'
         os:
-          - macOS-latest
+          - ubuntu-latest
           - windows-latest
+        arch:
+          - x64
         include:
-          - os: ubuntu-latest
-            arch: x64
+          - os: macOS-latest
+            arch: arm64
             version: '1.10'
           - os: ubuntu-latest
             arch: x86


### PR DESCRIPTION
I'm not sure I completely understand the logic of the tests (do we really have to test two Windows architectures? Do we have a good reason to think the code we write might work on one architecture but not the other?)

Hopefully this is an ok change and also addresses the @Sbozzolo found in specifying `x64` for macOS.