### PR TITLE
Remove concurrency on `init`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,8 +13,6 @@ env:
 steps:
   - label: "initialize"
     key: "init"
-    concurrency: 1
-    concurrency_group: 'depot/climaocean-ci'
     env:
       TEST_GROUP: "init"
     command:


### PR DESCRIPTION
We have a concurrency flag on the `init` step in CI that disallows multiple agents. We had problems of the whole CI pipeline stalling if one job stalls so maybe it is better to remove this flag. @Sbozzolo is this flag intentional? Will we incur problems on the Caltech cluster if we remove it?