### PR TITLE
Fix a precision problem in the ETOPO1 dataset

### DIFF
--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -111,8 +111,8 @@ function regrid_bathymetry(target_grid;
 
     FT = eltype(target_grid)
 
-    φ_data = dataset["lat"][:]
-    λ_data = dataset["lon"][:]
+    φ_data = dataset["lat"][:] 
+    λ_data = dataset["lon"][:] 
     z_data = convert(Array{FT}, dataset["z"][:, :])
 
     # Convert longitude from (-180, 180) to (0, 360)
@@ -142,8 +142,8 @@ function regrid_bathymetry(target_grid;
     jj = j₁:j₂
 
     # Restrict bathymetry _data to region of interest
-    λ_data = λ_data[ii]
-    φ_data = φ_data[jj]
+    λ_data = λ_data[ii] |> Array{BigFloat}
+    φ_data = φ_data[jj] |> Array{BigFloat}
     z_data = z_data[ii, jj] 
 
     if !isnothing(height_above_water)
@@ -158,10 +158,10 @@ function regrid_bathymetry(target_grid;
     Δλ = λ_data[2] - λ_data[1]
     Δφ = φ_data[2] - φ_data[1]
 
-    λ₁_data = Float64(λ_data[1]   - Δλ / 2)
-    λ₂_data = Float64(λ_data[end] + Δλ / 2)
-    φ₁_data = Float64(φ_data[1]   - Δφ / 2)
-    φ₂_data = Float64(φ_data[end] + Δφ / 2)
+    λ₁_data = convert(Float64, λ_data[1]   - Δλ / 2)
+    λ₂_data = convert(Float64, λ_data[end] + Δλ / 2)
+    φ₁_data = convert(Float64, φ_data[1]   - Δφ / 2)
+    φ₂_data = convert(Float64, φ_data[end] + Δφ / 2)
 
     Nxn = length(λ_data)
     Nyn = length(φ_data)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -111,8 +111,8 @@ function regrid_bathymetry(target_grid;
 
     FT = eltype(target_grid)
 
-    φ_data = dataset["lat"][:] 
-    λ_data = dataset["lon"][:] 
+    φ_data = dataset["lat"][:]
+    λ_data = dataset["lon"][:]
     z_data = convert(Array{FT}, dataset["z"][:, :])
 
     # Convert longitude from (-180, 180) to (0, 360)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -84,7 +84,6 @@ function regrid_bathymetry(target_grid;
                            url = "https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/60s/60s_surface_elev_netcdf", 
                            filename = "ETOPO_2022_v1_60s_N90W180_surface.nc",
                            interpolation_passes = 1,
-                           latitude_tolerance = 1e-10,
                            major_basins = Inf) # Allow an `Inf` number of ``lakes''
 
     filepath = joinpath(dir, filename)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -84,6 +84,7 @@ function regrid_bathymetry(target_grid;
                            url = "https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/60s/60s_surface_elev_netcdf", 
                            filename = "ETOPO_2022_v1_60s_N90W180_surface.nc",
                            interpolation_passes = 1,
+                           latitude_tolerance = 1e-10,
                            major_basins = Inf) # Allow an `Inf` number of ``lakes''
 
     filepath = joinpath(dir, filename)
@@ -144,7 +145,7 @@ function regrid_bathymetry(target_grid;
     # Restrict bathymetry _data to region of interest
     λ_data = λ_data[ii]
     φ_data = φ_data[jj]
-    z_data = z_data[ii, jj]
+    z_data = z_data[ii, jj] 
 
     if !isnothing(height_above_water)
         # Overwrite the height of cells above water.
@@ -158,10 +159,10 @@ function regrid_bathymetry(target_grid;
     Δλ = λ_data[2] - λ_data[1]
     Δφ = φ_data[2] - φ_data[1]
 
-    λ₁_data = λ_data[1]   - Δλ / 2
-    λ₂_data = λ_data[end] + Δλ / 2
-    φ₁_data = φ_data[1]   - Δφ / 2
-    φ₂_data = φ_data[end] + Δφ / 2
+    λ₁_data = Float64(λ_data[1]   - Δλ / 2)
+    λ₂_data = Float64(λ_data[end] + Δλ / 2)
+    φ₁_data = Float64(φ_data[1]   - Δφ / 2)
+    φ₂_data = Float64(φ_data[end] + Δφ / 2)
 
     Nxn = length(λ_data)
     Nyn = length(φ_data)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -141,7 +141,7 @@ function regrid_bathymetry(target_grid;
     j₂ = searchsortedfirst(φ_data, φ₂) - 1
     jj = j₁:j₂
 
-    # Restrict bathymetry _data to region of interest
+    # Restrict bathymetry coordinate_data to region of interest
     λ_data = λ_data[ii] |> Array{BigFloat}
     φ_data = φ_data[jj] |> Array{BigFloat}
     z_data = z_data[ii, jj] 


### PR DESCRIPTION
This PR addresses the precision problem that we incur if we want to regrid a bathymetry up to 90 degrees north.
We probably also want to allow some tolerance in `validate_lat_lon_grid_args` in Oceananigans.jl

https://github.com/CliMA/Oceananigans.jl/blob/f2a8fb32251135f9cd9b230e0873f7bc1936f762/src/Grids/latitude_longitude_grid.jl#L279-L285

see issue #205

