### PR TITLE
Fix a bug in `MinimumTemperatureSeaIce` and limit temperature in the water column

### DIFF
--- a/src/OceanSeaIceModels/minimum_temperature_sea_ice.jl
+++ b/src/OceanSeaIceModels/minimum_temperature_sea_ice.jl
@@ -43,9 +43,10 @@ end
                                          ocean_temperature)
 
     i, j = @index(Global, NTuple)
+    kᴺ = size(grid, 3) # index of the top ocean cell
 
     @inbounds begin
-        Tₒ = ocean_temperature[i, j, 1]
+        Tₒ = ocean_temperature[i, j, kᴺ]
 
         τx = centered_velocity_fluxes.u
         τy = centered_velocity_fluxes.v

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -154,7 +154,7 @@ end
 
     atmosphere = JRA55_prescribed_atmosphere(1:2; grid, backend = InMemory())
     
-    # Only specific terms above the minimum temperature
+    # Cap all fluxes exept for heating ones where T < -1.5
     sea_ice = MinimumTemperatureSeaIce(-1.5)
 
     fill!(ocean.model.tracers.T, -2.0)
@@ -170,7 +170,7 @@ end
     turbulent_fluxes = coupled_model.fluxes.turbulent.fields
 
     # Make sure that the fluxes are zero when the temperature is below the minimum
-    # but not zero when they are above    
+    # but not zero when it is above
     u, v, _ = ocean.model.velocities
     T, S    = ocean.model.tracers
 
@@ -178,7 +178,7 @@ end
         flux = surface_flux(field)
         @test flux[1, 2, 10] == 0.0 # below freezing and cooling, no flux
         @test flux[2, 1, 10] == 0.0 # below freezing and cooling, no flux
-        @test flux[1, 1, 10] == 0.0 # above freezing and cooling
-        @test flux[2, 2, 10] == 0.0 # above freezing and cooling
+        @test flux[1, 1, 10] != 0.0 # above freezing and cooling
+        @test flux[2, 2, 10] != 0.0 # above freezing and cooling
     end
 end

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -137,6 +137,33 @@ end
     @test turbulent_fluxes.sensible_heat[1, 1, 1] ≈ Qs
     @test turbulent_fluxes.latent_heat[1, 1, 1]   ≈ Ql
     @test turbulent_fluxes.water_vapor[1, 1, 1]   ≈ Mv
+
+    @info " Testing MinimumTemperatureSeaIce..." 
+
+    grid = LatitudeLongitudeGrid(size = (2, 2, 10), 
+                             latitude = (-0.5, 0.5), 
+                            longitude = (-0.5, 0.5), 
+                                    z = (-1, 0),
+                             topology = (Periodic, Periodic, Bounded))
+    
+    ocean = ocean_simulation(grid; momentum_advection = nothing, 
+                                     tracer_advection = nothing, 
+                                              closure = nothing,
+                              bottom_drag_coefficient = 0.0)
+
+    atmosphere = JRA55_prescribed_atmosphere(1:2; grid, backend = InMemory())
+
+    # Only specific terms above the minimum temperature
+    sea_ice = MinimumTemperatureSeaIce(-1.5)
+
+    fill!(ocean.model.tracers.T, -2.0)
+
+    ocean.model.tracers.T[1, 2, 10] = -1.0
+    ocean.model.tracers.T[2, 1, 10] = -1.0
+
+    coupled_model = OceanSeaIceModel(ocean, sea_ice; atmosphere)
+
+    turbulent_fluxes = coupled_model.fluxes.turbulent.fields
+
+    
 end
-
-


### PR DESCRIPTION
This was for sure the problem with the cooling case in #251 and I believe is also what is causing #237, 
because we cap cooling fluxes on the base of the temperature of the bottom cell.
This is almost always 0 in the arctic because it is immersed, causing cooling fluxes to always be active and reducing the temperature much below the freezing point. I am not sure about the temperature increasing too much in the tropics though.

I ll also build the examples to see if this is the problem