### PR TITLE
Fix JRA55 tests

### DIFF
--- a/test/test_jra55.jl
+++ b/test/test_jra55.jl
@@ -108,7 +108,7 @@ using ClimaOcean.OceanSeaIceModels: PrescribedAtmosphere
         # What else might we test?
 
         @info "Testing save_field_time_series! on $A..."
-        filepath = "JRA55_downwelling_shortwave_radiation_test.jld2"
+        filepath = "JRA55_downwelling_shortwave_radiation_test_$(string(typeof(arch))).jld2"
         ClimaOcean.DataWrangling.save_field_time_series!(target_fts, path=filepath, name="Qsw",
                                                          overwrite_existing = true)
         @test isfile(filepath)

--- a/test/test_jra55.jl
+++ b/test/test_jra55.jl
@@ -108,7 +108,7 @@ using ClimaOcean.OceanSeaIceModels: PrescribedAtmosphere
         # What else might we test?
 
         @info "Testing save_field_time_series! on $A..."
-        filepath = "JRA55_downwelling_shortwave_radiation_test_$(string(typeof(arch))).jld2"
+        filepath = "JRA55_downwelling_shortwave_radiation_test_$(string(typeof(arch))).jld2" # different filename for each arch so that the CPU and GPU tests do not crash
         ClimaOcean.DataWrangling.save_field_time_series!(target_fts, path=filepath, name="Qsw",
                                                          overwrite_existing = true)
         @test isfile(filepath)


### PR DESCRIPTION
This makes sure that the CPU and GPU tests handle different files so that the tests do not crash