### PR TITLE
Change default major basins to 1 in `regrid_bathymetry`

### DIFF
--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -90,7 +90,7 @@ function regrid_bathymetry(target_grid;
                            url = "https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/60s/60s_surface_elev_netcdf", 
                            filename = "ETOPO_2022_v1_60s_N90W180_surface.nc",
                            interpolation_passes = 1,
-                           major_basins = Inf) # Allow an `Inf` number of ``lakes''
+                           major_basins = 1) # Allow an `Inf` number of ``lakes''
 
     filepath = joinpath(dir, filename)
     fileurl  = url * "/" * filename # joinpath on windows creates the wrong url


### PR DESCRIPTION
I can't really think of a case where we would want more than one major basin, let alone an infinite number of basins!