### PR TITLE
Corrected `ECCOMetaData` code bit in tutorial to `dates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ grid = ImmersedBoundaryGrid(grid, GridFittedBottom(bathymetry))
 # Build an ocean simulation initialized to the ECCO state estimate on Jan 1, 1993
 ocean = ClimaOcean.ocean_simulation(grid)
 date  = DateTimeProlepticGregorian(1993, 1, 1)
-set!(ocean.model, T = ClimaOcean.ECCOMetadata(:temperature; date),
-                  S = ClimaOcean.ECCOMetadata(:salinity; date))
+set!(ocean.model, T = ClimaOcean.ECCOMetadata(:temperature, dates= date),
+                  S = ClimaOcean.ECCOMetadata(:salinity, dates= date))
 
 # Build and run an OceanSeaIceModel (with no sea ice component) forced by JRA55 reanalysis
 atmosphere = ClimaOcean.JRA55PrescribedAtmosphere(arch)


### PR DESCRIPTION
In reference to Issues #224 and #227, the tutorial in `readme.md` contains
```
set!(ocean.model, T = ClimaOcean.ECCOMetadata(:temperature; date),
                  S = ClimaOcean.ECCOMetadata(:salinity; date))`
```
This results in the error:
```
MethodError: no method matching ClimaOcean.DataWrangling.ECCO.ECCOMetadata(::Symbol; date::DateTimeProlepticGregorian)
```
Signatures of the function indicate:
```
methods(ClimaOcean.ECCOMetadata)
[1] ClimaOcean.DataWrangling.ECCO.ECCOMetadata(name::Symbol; dates, version, dir)
[2] ClimaOcean.DataWrangling.ECCO.ECCOMetadata(name::Symbol, date; ...)
[3] ClimaOcean.DataWrangling.ECCO.ECCOMetadata(name::Symbol, date, version; dir)
[4] ClimaOcean.DataWrangling.ECCO.ECCOMetadata(name::Symbol, dates::D, version::V, dir::String) where {D, V}
```
 The following version seems to work:
 ```
 set!(ocean.model, 
     T = ClimaOcean.ECCOMetadata(:temperature; dates=[date]), 
     S = ClimaOcean.ECCOMetadata(:salinity; dates=[date]))
```                 
I continue to face errors regarding ECCO data post 1995 but that's a 401 login node error 😄  