### PR TITLE
Update to climacommon 2024_10_10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_10_08
+  modules: climacommon/2024_10_10
 
 timeout_in_minutes: 1440
 


### PR DESCRIPTION
This makes the test pipeline use a newer version of Julia which is required to avoid a bug with extensions in older versions of 1.10.