### PR TITLE
Fix a small bug in bathymetry

### DIFF
--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -151,7 +151,6 @@ function regrid_bathymetry(target_grid;
     Nyn = length(φ_data)
     Nzn = 1
 
-  
     native_grid = LatitudeLongitudeGrid(arch, Float32;
                                         size = (Nxn, Nyn, Nzn),
                                         latitude  = (φ₁_data, φ₂_data),

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -195,8 +195,8 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     resxn = minimum_xspacing(native_z.grid)
     resyn = minimum_yspacing(native_z.grid)
 
-    # Check whether we are coarsening the grid in any directions.
-    # If so, skip interpolation passes.
+    # Check whether we are refining the grid in any directions.
+    # If so, skip interpolation passes, as they are not needed.
     if resxt < resxn || resyt < resyn
         target_z = Field{Center, Center, Nothing}(target_grid)
         interpolate!(target_z, native_z)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -202,8 +202,8 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
         interpolate!(target_z, native_z)
         @info string("Skipping passes for interpolating bathymetry of size $Nn ", '\n',
                      "to target grid of size $Nt. Interpolation passes may only ", '\n',
-                     "be used to refine bathymetry and require that the bathymetry ", '\n',
-                     "is larger than the target grid in both horizontal directions.")
+                     "be used to coarsen bathymetry and require that the bathymetry ", '\n',
+                     "is finer than the target grid in both horizontal directions.")
         return target_z
     end
  

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -197,7 +197,7 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
 
     # Check whether we are coarsening the grid in any directions.
     # If so, skip interpolation passes.
-    if resxt > resxn || resyt > resyn
+    if resxt < resxn || resyt < resyn
         target_z = Field{Center, Center, Nothing}(target_grid)
         interpolate!(target_z, native_z)
         @info string("Skipping passes for interpolating bathymetry of size $Nn ", '\n',

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -51,7 +51,7 @@ using ClimaOcean.Bathymetry: remove_minor_basins!
         grid = LatitudeLongitudeGrid(arch;
                                      size = (200, 200, 10),
                                      longitude = (0, 2),
-                                     latitude = (-10, 50),
+                                     latitude = (-0.1, 0.1),
                                      z = (-6000, 0))
 
         control_bottom_height = regrid_bathymetry(grid)

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -59,5 +59,17 @@ using ClimaOcean.Bathymetry: remove_minor_basins!
 
         # Testing that multiple passes do not change the solution when refining the grid
         @test parent(control_bottom_height) == parent(interpolated_bottom_height)
+
+        grid = LatitudeLongitudeGrid(arch;
+                                     size = (200, 200, 10),
+                                     longitude = (0, 100),
+                                     latitude = (-10, 50),
+                                     z = (-6000, 0))
+
+        control_bottom_height = regrid_bathymetry(grid)
+        interpolated_bottom_height = regrid_bathymetry(grid; interpolation_passes=10)
+
+        # Testing that multiple passes _do_ change the solution when coarsening the grid
+        @test parent(control_bottom_height) != parent(interpolated_bottom_height)
     end
 end


### PR DESCRIPTION
I have introduced a small bug in the last bathymetry PR, where we never perform passes.
This PR does a small correction for the moment. 

Then we can think (in another PR) to change this piece of code to do diffusion of the bathymetry based on a maximum slope approach.