### PR TITLE
[CI] Some improvements to GitHub Actions setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,29 @@
 name: CI
+
 on:
-  push:
-    branches: [main]
-    tags: ["*"]
   pull_request:
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'ext/**'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
+  push:
+    branches:
+      - main
+    tags: '*'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'ext/**'
+      - 'src/**'
+      - 'test/**'
+      - 'Project.toml'
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +39,7 @@ jobs:
             arch: x86
             version: '1.10'
           - os: macOS-latest
-            arch: arm64
+            arch: aarch64
             version: '1.10'
           - os: ubuntu-latest
             arch: x86
@@ -33,28 +49,16 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Install dependencies
-        run: |
-          julia --color=yes --project -e 'using Pkg; Pkg.instantiate()'
-          julia --color=yes --project -e 'using Pkg; Pkg.precompile()'
-          julia --color=yes --project -e 'using Pkg; Pkg.test()'
+      - uses: julia-actions/julia-runtest@v1
         env:
           TEST_GROUP: "downloading"
           ECCO_USERNAME: ${{ secrets.ECCO_USERNAME }} # To download ECCO data from the podaac website
           ECCO_PASSWORD: ${{ secrets.ECCO_PASSWORD }} # To download ECCO data from the podaac website
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - '.github/workflows/ci.yml'
       - 'ext/**'


### PR DESCRIPTION
* Install Dependabot
* Trigger on pull requests, pushes to `main` and tags, when editing relevant files
* Add concurrency group to cancel subsequent jobs in PRs. This is particularly useful to cancelling quickly macOS jobs, since there are only 5 concurrent runners available for the entire organisation
* Use `julia-actions/cache` instead of `actions/cache`
* Add timeouts, to avoid hanging jobs hold on to the runners for 6 hours
* Actually use the `matrix.arch` argument to install the desired julia build. At the moment that was completely unused, resulting in duplicate jobs

Similar to https://github.com/CliMA/Oceananigans.jl/pull/4198.
