### PR TITLE
Precompile a bit less?

### DIFF
--- a/src/ClimaOcean.jl
+++ b/src/ClimaOcean.jl
@@ -100,7 +100,6 @@ using PrecompileTools: @setup_workload, @compile_workload
         grid = Oceananigans.OrthogonalSphericalShellGrids.TripolarGrid(CPU(); size=(Nx, Ny, Nz), halo=(7, 7, 7), z)
         grid = ImmersedBoundaryGrid(grid, GridFittedBottom((x, y) -> -5000))
         ocean = ocean_simulation(grid)
-        model = OceanSeaIceModel(ocean)
     end
 end
 


### PR DESCRIPTION
This PR changes so we only precompile `ocean_simulation` and not `OceanSeaIceModel`. I do think that precompiling `ocean_simulation` is more important but I don't have an idea of how much it helps to precompile `OceanSeaIceModel`.