### PR TITLE
Separate gravitational_acceleration from flux_formulation

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -51,7 +51,8 @@ function compute_atmosphere_ocean_fluxes!(coupled_model)
             atmosphere_data,
             interface_properties,
             atmosphere_properties,
-            ocean_properties)
+            ocean_properties,
+            coupled_model.interfaces.gravitational_acceleration)
 
     return nothing
 end
@@ -66,7 +67,8 @@ end
                                                             atmosphere_state,
                                                             interface_properties,
                                                             atmosphere_properties,
-                                                            ocean_properties)
+                                                            ocean_properties,
+                                                            gravitational_acceleration)
 
     i, j = @index(Global, NTuple)
     kᴺ   = size(grid, 3) # index of the top ocean cell
@@ -102,6 +104,7 @@ end
                               u = uₐ,
                               v = vₐ,
                               𝒬 = 𝒬ₐ,
+                              g = gravitational_acceleration,
                               h_bℓ = atmosphere_state.h_bℓ)
 
     local_interior_state = (u=uᵢ, v=vᵢ, T=Tᵢ, S=Sᵢ)

--- a/src/OceanSeaIceModels/InterfaceComputations/atmosphere_sea_ice_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/atmosphere_sea_ice_fluxes.jl
@@ -55,7 +55,8 @@ function compute_atmosphere_sea_ice_fluxes!(coupled_model)
             interface_properties,
             atmosphere_properties,
             sea_ice_properties,
-            ocean_properties)
+            ocean_properties,
+            coupled_model.interfaces.gravitational_acceleration)
 
     return nothing
 end
@@ -71,7 +72,8 @@ end
                                                               interface_properties,
                                                               atmosphere_properties,
                                                               sea_ice_properties,
-                                                              ocean_properties)
+                                                              ocean_properties,
+                                                              gravitational_acceleration)
 
     i, j = @index(Global, NTuple)
     kᴺ   = size(grid, 3) # index of the top ocean cell
@@ -113,6 +115,7 @@ end
                               u = uₐ,
                               v = vₐ,
                               𝒬 = 𝒬ₐ,
+                              g = gravitational_acceleration,
                               h_bℓ = atmosphere_state.h_bℓ)
 
     downwelling_radiation = (; Qs, Qℓ)

--- a/src/OceanSeaIceModels/InterfaceComputations/coefficient_based_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/coefficient_based_turbulent_fluxes.jl
@@ -1,8 +1,7 @@
 using Oceananigans.BuoyancyFormulations: g_Earth
 
-struct CoefficientBasedFluxes{CD, CH, CQ, FT, S}
+struct CoefficientBasedFluxes{CD, CH, CQ, S}
     drag_coefficient :: CD
-    gravitational_acceleration :: FT
     heat_transfer_coefficient :: CH
     vapor_flux_coefficient :: CQ
     solver_stop_criteria :: S
@@ -13,7 +12,6 @@ convert_if_number(FT, a) = a
 
 function CoefficientBasedFluxes(FT = Oceananigans.defaults.FloatType;
                                 drag_coefficient = 1e-3,
-                                gravitational_acceleration = g_Earth,
                                 heat_transfer_coefficient = drag_coefficient,
                                 vapor_flux_coefficient = drag_coefficient,
                                 solver_stop_criteria = nothing,
@@ -30,7 +28,6 @@ function CoefficientBasedFluxes(FT = Oceananigans.defaults.FloatType;
     vapor_flux_coefficient = convert_if_number(FT, vapor_flux_coefficient)
 
     return CoefficientBasedFluxes(drag_coefficient,
-                                  gravitational_acceleration,
                                   heat_transfer_coefficient,
                                   vapor_flux_coefficient,
                                   solver_stop_criteria)

--- a/src/OceanSeaIceModels/InterfaceComputations/component_interfaces.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/component_interfaces.jl
@@ -17,6 +17,7 @@ using ..OceanSeaIceModels.PrescribedAtmospheres:
 
 using ClimaSeaIce: SeaIceModel
 
+using Oceananigans.BuoyancyFormulations: g_Earth
 using Oceananigans: HydrostaticFreeSurfaceModel, architecture
 using Oceananigans.Grids: inactive_node, node, topology
 using Oceananigans.BoundaryConditions: fill_halo_regions!
@@ -48,7 +49,7 @@ mutable struct SeaIceOceanInterface{J, P, H, A}
     previous_ice_concentration :: A
 end
 
-mutable struct ComponentInterfaces{AO, ASI, SIO, C, AP, OP, SIP, EX}
+mutable struct ComponentInterfaces{AO, ASI, SIO, C, AP, OP, SIP, EX, FT}
     atmosphere_ocean_interface :: AO
     atmosphere_sea_ice_interface :: ASI
     sea_ice_ocean_interface :: SIO
@@ -57,6 +58,7 @@ mutable struct ComponentInterfaces{AO, ASI, SIO, C, AP, OP, SIP, EX}
     sea_ice_properties :: SIP
     exchanger :: EX
     net_fluxes :: C
+    gravitational_acceleration :: FT
 end
 
 mutable struct StateExchanger{G, AST, AEX}
@@ -281,9 +283,7 @@ end
                         radiation = Radiation(),
                         freshwater_density = 1000,
                         atmosphere_ocean_flux_formulation = SimilarityTheoryFluxes(),
-                        atmosphere_sea_ice_flux_formulation = CoefficientBasedFluxes(drag_coefficient=2e-3,
-                                                                                     heat_transfer_coefficient=1e-4,
-                                                                                     vapor_flux_coefficient=1e-4),
+                        atmosphere_sea_ice_flux_formulation = SimilarityTheoryFluxes(eltype(ocean.model.grid)),
                         atmosphere_ocean_interface_temperature = BulkTemperature(),
                         atmosphere_ocean_interface_specific_humidity = default_ao_specific_humidity(ocean),
                         atmosphere_sea_ice_interface_temperature = default_ai_temperature(sea_ice),
@@ -292,7 +292,8 @@ end
                         ocean_temperature_units = DegreesCelsius(),
                         sea_ice_temperature_units = DegreesCelsius(),
                         sea_ice_reference_density = reference_density(sea_ice),
-                        sea_ice_heat_capacity = heat_capacity(sea_ice))
+                        sea_ice_heat_capacity = heat_capacity(sea_ice),
+                        gravitational_acceleration = g_Earth)
 """
 function ComponentInterfaces(atmosphere, ocean, sea_ice=nothing;
                              radiation = Radiation(),
@@ -309,16 +310,18 @@ function ComponentInterfaces(atmosphere, ocean, sea_ice=nothing;
                              ocean_temperature_units = DegreesCelsius(),
                              sea_ice_temperature_units = DegreesCelsius(),
                              sea_ice_reference_density = reference_density(sea_ice),
-                             sea_ice_heat_capacity = heat_capacity(sea_ice))
+                             sea_ice_heat_capacity = heat_capacity(sea_ice),
+                             gravitational_acceleration = g_Earth)
 
     ocean_grid = ocean.model.grid
     FT = eltype(ocean_grid)
-
-    ocean_reference_density   = convert(FT, ocean_reference_density)
-    ocean_heat_capacity       = convert(FT, ocean_heat_capacity)
-    sea_ice_reference_density = convert(FT, sea_ice_reference_density)
-    sea_ice_heat_capacity     = convert(FT, sea_ice_heat_capacity)
-    freshwater_density        = convert(FT, freshwater_density)
+ 
+    ocean_reference_density    = convert(FT, ocean_reference_density)
+    ocean_heat_capacity        = convert(FT, ocean_heat_capacity)
+    sea_ice_reference_density  = convert(FT, sea_ice_reference_density)
+    sea_ice_heat_capacity      = convert(FT, sea_ice_heat_capacity)
+    freshwater_density         = convert(FT, freshwater_density)
+    gravitational_acceleration = convert(FT, gravitational_acceleration)
 
     atmosphere_properties = thermodynamics_parameters(atmosphere)
 
@@ -394,7 +397,8 @@ function ComponentInterfaces(atmosphere, ocean, sea_ice=nothing;
                                ocean_properties,
                                sea_ice_properties,
                                exchanger,
-                               net_fluxes)
+                               net_fluxes,
+                               gravitational_acceleration)
 end
 
 sea_ice_similarity_theory(sea_ice) = nothing

--- a/src/OceanSeaIceModels/InterfaceComputations/compute_interface_state.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/compute_interface_state.jl
@@ -99,14 +99,7 @@ and interior properties `ℙₛ`, `ℙₐ`, and `ℙᵢ`.
     qₐ = AtmosphericThermodynamics.vapor_specific_humidity(ℂₐ, 𝒬ₐ)
     Δq = qₐ - qₛ
 
-    # Temperature increment including the ``lapse rate'' `α = g / cₚ`
-    zₐ = atmosphere_state.z
-    zₛ = zero(FT)
-    Δh = zₐ - zₛ
-    Tₐ = AtmosphericThermodynamics.air_temperature(ℂₐ, 𝒬ₐ)
-    g  = flux_formulation.gravitational_acceleration
-    cₐ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ)
-    θₐ = Tₐ + g * Δh / cₐ
+    θₐ = surface_atmosphere_temperature(atmosphere_state, atmosphere_properties)
     Δθ = θₐ - Tₛ
 
     u★, θ★, q★ = iterate_interface_fluxes(flux_formulation,
@@ -121,4 +114,16 @@ and interior properties `ℙₛ`, `ℙₐ`, and `ℙᵢ`.
     S = approximate_interface_state.S
 
     return InterfaceState(u★, θ★, q★, u, v, Tₛ, S, convert(FT, qₛ))
+end
+
+# Temperature increment including the ``lapse rate'' `α = g / cₚ`
+function surface_atmosphere_temperature(Ψₐ, ℙₐ)
+    ℂₐ = ℙₐ.thermodynamics_parameters
+    𝒬ₐ = Ψₐ.𝒬
+    zₐ = Ψₐ.z
+    Δh = zₐ # Assumption! The surface is at z = 0 -> Δh = zₐ - 0
+    Tₐ = AtmosphericThermodynamics.air_temperature(ℂₐ, 𝒬ₐ)
+    cₐ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ)
+    g  = Ψₐ.g
+    return Tₐ + g * Δh / cₐ
 end


### PR DESCRIPTION
We need it to compute air temperature so it does not really fit in the flux_formulation, but in a more upstream data structure. I have thought to put it directly in `ComponentInterfaces` and then pass it to `atmosphere_properties` inside the compute fluxes function, but I am happy to shift it around somewhere else.

This PR is needed for #433 