### PR TITLE
Use separate representations of the barotropic potential for u,v

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/interpolate_atmospheric_state.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/interpolate_atmospheric_state.jl
@@ -110,11 +110,18 @@ function interpolate_atmosphere_state!(interfaces, atmosphere::PrescribedAtmosph
     end
 
     # Set ocean barotropic pressure forcing
+    #
+    # TODO: find a better design for this that doesn't have redundant
+    # arrays for the barotropic potential
     u_potential = forcing_barotropic_potential(ocean.model.forcing.u)
     v_potential = forcing_barotropic_potential(ocean.model.forcing.v)
     ρₒ = coupled_model.interfaces.ocean_properties.reference_density
-    if !isnothing(barotropic_potential)
+
+    if !isnothing(u_potential)
         parent(u_potential) .= parent(atmosphere_data.p) ./ ρₒ
+    end
+
+    if !isnothing(v_potential)
         parent(v_potential) .= parent(atmosphere_data.p) ./ ρₒ
     end
 end

--- a/src/OceanSeaIceModels/InterfaceComputations/interpolate_atmospheric_state.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/interpolate_atmospheric_state.jl
@@ -110,10 +110,12 @@ function interpolate_atmosphere_state!(interfaces, atmosphere::PrescribedAtmosph
     end
 
     # Set ocean barotropic pressure forcing
-    barotropic_potential = forcing_barotropic_potential(ocean)
+    u_potential = forcing_barotropic_potential(ocean.model.forcing.u)
+    v_potential = forcing_barotropic_potential(ocean.model.forcing.v)
     ρₒ = coupled_model.interfaces.ocean_properties.reference_density
     if !isnothing(barotropic_potential)
-        parent(barotropic_potential) .= parent(atmosphere_data.p) ./ ρₒ
+        parent(u_potential) .= parent(atmosphere_data.p) ./ ρₒ
+        parent(v_potential) .= parent(atmosphere_data.p) ./ ρₒ
     end
 end
 

--- a/src/OceanSimulations/ocean_simulation.jl
+++ b/src/OceanSimulations/ocean_simulation.jl
@@ -153,9 +153,10 @@ function ocean_simulation(grid;
         v_immersed_bc = ImmersedBoundaryCondition(bottom=v_immersed_drag)
 
         # Forcing for u, v
-        barotropic_potential = Field{Center, Center, Nothing}(grid)
-        u_forcing = BarotropicPotentialForcing(XDirection(), barotropic_potential)
-        v_forcing = BarotropicPotentialForcing(YDirection(), barotropic_potential)
+        u_barotropic_potential = Field{Center, Center, Nothing}(grid)
+        v_barotropic_potential = Field{Center, Center, Nothing}(grid)
+        u_forcing = BarotropicPotentialForcing(XDirection(), u_barotropic_potential)
+        v_forcing = BarotropicPotentialForcing(YDirection(), v_barotropic_potential)
 
         :u ∈ keys(forcing) && (u_forcing = (u_forcing, forcing[:u]))
         :v ∈ keys(forcing) && (v_forcing = (v_forcing, forcing[:v]))


### PR DESCRIPTION
This avoids potential issues associated with array aliasing / passing the same array into a kernel twice. cc @wsmoses 