### PR TITLE
Switch metadata type parameters

### DIFF
--- a/src/DataWrangling/ECCO/ECCO_metadata.jl
+++ b/src/DataWrangling/ECCO/ECCO_metadata.jl
@@ -15,7 +15,7 @@ struct ECCO2Monthly end
 struct ECCO2Daily end
 struct ECCO4Monthly end
 
-const ECCOMetadata{D} = Metadata{<:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}, D} where {D}
+const ECCOMetadata{D} = Metadata{<:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}, D}
 const ECCOMetadatum   = Metadatum{<:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}}
 
 const ECCO2_url = "https://ecco.jpl.nasa.gov/drive/files/ECCO2/cube92_latlon_quart_90S90N/"

--- a/src/DataWrangling/ECCO/ECCO_metadata.jl
+++ b/src/DataWrangling/ECCO/ECCO_metadata.jl
@@ -16,7 +16,7 @@ struct ECCO2Daily end
 struct ECCO4Monthly end
 
 const ECCOMetadata{D} = Metadata{<:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}, D} where {D}
-const ECCOMetadatum   = ECCOMetadata{<:AnyDateTime}
+const ECCOMetadatum   = Metadatum{<:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}}
 
 const ECCO2_url = "https://ecco.jpl.nasa.gov/drive/files/ECCO2/cube92_latlon_quart_90S90N/"
 const ECCO4_url = "https://ecco.jpl.nasa.gov/drive/files/Version4/Release4/interp_monthly/"

--- a/src/DataWrangling/ECCO/ECCO_metadata.jl
+++ b/src/DataWrangling/ECCO/ECCO_metadata.jl
@@ -15,7 +15,7 @@ struct ECCO2Monthly end
 struct ECCO2Daily end
 struct ECCO4Monthly end
 
-const ECCOMetadata{D} = Metadata{D, <:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}} where {D}
+const ECCOMetadata{D} = Metadata{<:Union{<:ECCO2Monthly, <:ECCO2Daily, <:ECCO4Monthly}, D} where {D}
 const ECCOMetadatum   = ECCOMetadata{<:AnyDateTime}
 
 const ECCO2_url = "https://ecco.jpl.nasa.gov/drive/files/ECCO2/cube92_latlon_quart_90S90N/"
@@ -45,13 +45,13 @@ datestr(md::ECCOMetadatum) = string(md.dates)
 Base.summary(md::ECCOMetadata) = string("ECCOMetadata{", datasetstr(md), "} of ",
                                         md.name, " for ", datestr(md))
 
-Base.size(data::Metadata{<:Any, <:ECCO2Daily})   = (1440, 720, 50, length(data.dates))
-Base.size(data::Metadata{<:Any, <:ECCO2Monthly}) = (1440, 720, 50, length(data.dates))
-Base.size(data::Metadata{<:Any, <:ECCO4Monthly}) = (720,  360, 50, length(data.dates))
+Base.size(data::Metadata{<:ECCO2Daily})   = (1440, 720, 50, length(data.dates))
+Base.size(data::Metadata{<:ECCO2Monthly}) = (1440, 720, 50, length(data.dates))
+Base.size(data::Metadata{<:ECCO4Monthly}) = (720,  360, 50, length(data.dates))
 
-Base.size(::Metadata{<:AnyDateTime, <:ECCO2Daily})   = (1440, 720, 50, 1)
-Base.size(::Metadata{<:AnyDateTime, <:ECCO2Monthly}) = (1440, 720, 50, 1)
-Base.size(::Metadata{<:AnyDateTime, <:ECCO4Monthly}) = (720,  360, 50, 1)
+Base.size(::Metadatum{<:ECCO2Daily})   = (1440, 720, 50, 1)
+Base.size(::Metadatum{<:ECCO2Monthly}) = (1440, 720, 50, 1)
+Base.size(::Metadatum{<:ECCO4Monthly}) = (720,  360, 50, 1)
 
 # The whole range of dates in the different dataset datasets
 all_dates(::ECCO4Monthly, name) = DateTime(1992, 1, 1) : Month(1) : DateTime(2023, 12, 1)
@@ -63,14 +63,14 @@ all_dates(::ECCO2Daily, name)   = DateTime(1992, 1, 4) : Day(1)   : DateTime(202
 all_dates(dataset::Union{<:ECCO4Monthly, <:ECCO2Monthly, <:ECCO2Daily}) = all_dates(dataset, :temperature)
 
 # File name generation specific to each Dataset dataset
-function metadata_filename(metadata::Metadata{<:AnyDateTime, <:ECCO4Monthly})
+function metadata_filename(metadata::Metadatum{<:ECCO4Monthly})
     shortname = short_name(metadata)
     yearstr  = string(Dates.year(metadata.dates))
     monthstr = string(Dates.month(metadata.dates), pad=2)
     return shortname * "_" * yearstr * "_" * monthstr * ".nc"
 end
 
-function metadata_filename(metadata::Metadata{<:AnyDateTime, <:Union{ECCO2Daily, ECCO2Monthly}})
+function metadata_filename(metadata::Metadatum{<:Union{ECCO2Daily, ECCO2Monthly}})
     shortname   = short_name(metadata)
     yearstr  = string(Dates.year(metadata.dates))
     monthstr = string(Dates.month(metadata.dates), pad=2)
@@ -85,9 +85,9 @@ function metadata_filename(metadata::Metadata{<:AnyDateTime, <:Union{ECCO2Daily,
 end
 
 # Convenience functions
-short_name(data::Metadata{<:Any, <:ECCO2Daily})   = ECCO2_short_names[data.name]
-short_name(data::Metadata{<:Any, <:ECCO2Monthly}) = ECCO2_short_names[data.name]
-short_name(data::Metadata{<:Any, <:ECCO4Monthly}) = ECCO4_short_names[data.name]
+short_name(data::Metadata{<:ECCO2Daily})   = ECCO2_short_names[data.name]
+short_name(data::Metadata{<:ECCO2Monthly}) = ECCO2_short_names[data.name]
+short_name(data::Metadata{<:ECCO4Monthly}) = ECCO4_short_names[data.name]
 
 location(data::ECCOMetadata) = ECCO_location[data.name]
 
@@ -131,10 +131,10 @@ ECCO_location = Dict(
 )
 
 # URLs for the ECCO datasets specific to each dataset
-metadata_url(m::Metadata{<:Any, <:ECCO2Daily})   = ECCO2_url *  "monthly/" * short_name(m) * "/" * metadata_filename(m)
-metadata_url(m::Metadata{<:Any, <:ECCO2Monthly}) = ECCO2_url *  "daily/"   * short_name(m) * "/" * metadata_filename(m)
+metadata_url(m::Metadata{<:ECCO2Daily})   = ECCO2_url *  "monthly/" * short_name(m) * "/" * metadata_filename(m)
+metadata_url(m::Metadata{<:ECCO2Monthly}) = ECCO2_url *  "daily/"   * short_name(m) * "/" * metadata_filename(m)
 
-function metadata_url(m::Metadata{<:Any, <:ECCO4Monthly})
+function metadata_url(m::Metadata{<:ECCO4Monthly})
     year = string(Dates.year(m.dates))
     return ECCO4_url * short_name(m) * "/" * year * "/" * metadata_filename(m)
 end

--- a/src/DataWrangling/ECCO/ECCO_restoring.jl
+++ b/src/DataWrangling/ECCO/ECCO_restoring.jl
@@ -148,7 +148,7 @@ function ECCOFieldTimeSeries(variable_name::Symbol;
 
     native_dates = all_dates(dataset, variable_name)
     dates = compute_native_date_range(native_dates, start_date, end_date)                          
-    metadata = Metadata(variable_name, dates, dataset, dir)
+    metadata = Metadata(variable_name, dataset, dates, dir)
     return ECCOFieldTimeSeries(metadata, architecture; kw...)
 end
 
@@ -301,7 +301,7 @@ function ECCORestoring(variable_name::Symbol,
 
     native_dates = all_dates(dataset, variable_name)
     dates = compute_native_date_range(native_dates, start_date, end_date)                          
-    metadata = Metadata(variable_name, dates, dataset, dir)
+    metadata = Metadata(variable_name, dataset, dates, dir)
 
     return ECCORestoring(metadata, arch_or_grid; kw...)
 end

--- a/src/DataWrangling/JRA55/JRA55_field_time_series.jl
+++ b/src/DataWrangling/JRA55/JRA55_field_time_series.jl
@@ -193,7 +193,7 @@ Keyword arguments
              * `JRA55NetCDFBackend(total_time_instances_in_memory)`: only a subset of the time series is loaded into memory.
              Default: `InMemory()`.
 """
-function JRA55FieldTimeSeries(variable_name::Symbol, architecture = CPU(), FT=Float32;
+function JRA55FieldTimeSeries(variable_name::Symbol, architecture=CPU(), FT=Float32;
                               dataset = JRA55RepeatYear(),
                               start_date = first_date(dataset, variable_name),
                               end_date = last_date(dataset, variable_name),
@@ -224,7 +224,7 @@ function JRA55FieldTimeSeries(metadata::JRA55Metadata, architecture=CPU(), FT=Fl
 
     # Change the metadata to reflect the actual time indices
     dates    = all_dates(dataset, name)[time_indices]
-    metadata = Metadata(metadata.name, dates, metadata.dataset, metadata.dir)
+    metadata = Metadata(metadata.name, metadata.dataset, dates, metadata.dir)
 
     shortname = short_name(metadata)
     variable_name = metadata.name

--- a/src/DataWrangling/JRA55/JRA55_field_time_series.jl
+++ b/src/DataWrangling/JRA55/JRA55_field_time_series.jl
@@ -203,7 +203,7 @@ function JRA55FieldTimeSeries(variable_name::Symbol, architecture = CPU(), FT=Fl
     native_dates = all_dates(dataset, variable_name)
     dates = compute_native_date_range(native_dates, start_date, end_date)                          
 
-    metadata = Metadata(variable_name, dates, dataset, dir)
+    metadata = Metadata(variable_name, dataset, dates, dir)
 
     return JRA55FieldTimeSeries(metadata, architecture, FT; kw...)
 end

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -152,7 +152,7 @@ variable_is_three_dimensional(data::JRA55Metadata) = false
 
 metadata_url(metadata::Metadata{<:JRA55RepeatYear}) = JRA55_repeat_year_urls[metadata.name]
 # TODO:
-# metadata_url(metadata::Metadata{<:Any, <:JRA55MultipleYears}) = ...
+# metadata_url(metadata::Metadata{<:JRA55MultipleYears}) = ...
 
 function download_dataset(metadata::JRA55Metadata)
 

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -18,7 +18,7 @@ struct JRA55MultipleYears end
 struct JRA55RepeatYear end
 
 const JRA55Metadata{D} = Metadata{<:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}, D} where {D}
-const JRA55Metadatum   = JRA55Metadata{<:AnyDateTime}
+const JRA55Metadatum   = Metadatum{<:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}}
 
 default_download_directory(::Union{<:JRA55MultipleYears, <:JRA55RepeatYear}) = download_JRA55_cache
 

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -17,7 +17,7 @@ import ClimaOcean.DataWrangling: all_dates, metadata_filename, download_dataset,
 struct JRA55MultipleYears end
 struct JRA55RepeatYear end
 
-const JRA55Metadata{D} = Metadata{D, <:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}} where {D}
+const JRA55Metadata{D} = Metadata{<:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}, D} where {D}
 const JRA55Metadatum   = JRA55Metadata{<:AnyDateTime}
 
 default_download_directory(::Union{<:JRA55MultipleYears, <:JRA55RepeatYear}) = download_JRA55_cache
@@ -59,7 +59,7 @@ function JRA55_time_indices(dataset, dates, name)
 end
 
 # File name generation specific to each Dataset dataset
-function metadata_filename(metadata::Metadata{<:Any, <:JRA55RepeatYear}) # No difference
+function metadata_filename(metadata::Metadata{<:JRA55RepeatYear}) # No difference
     shortname = short_name(metadata)
     return "RYF." * shortname * ".1990_1991.nc"
 end
@@ -150,7 +150,7 @@ JRA55_repeat_year_urls = Dict(
 
 variable_is_three_dimensional(data::JRA55Metadata) = false
 
-metadata_url(metadata::Metadata{<:Any, <:JRA55RepeatYear}) = JRA55_repeat_year_urls[metadata.name]
+metadata_url(metadata::Metadata{<:JRA55RepeatYear}) = JRA55_repeat_year_urls[metadata.name]
 # TODO:
 # metadata_url(metadata::Metadata{<:Any, <:JRA55MultipleYears}) = ...
 

--- a/src/DataWrangling/JRA55/JRA55_metadata.jl
+++ b/src/DataWrangling/JRA55/JRA55_metadata.jl
@@ -17,7 +17,7 @@ import ClimaOcean.DataWrangling: all_dates, metadata_filename, download_dataset,
 struct JRA55MultipleYears end
 struct JRA55RepeatYear end
 
-const JRA55Metadata{D} = Metadata{<:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}, D} where {D}
+const JRA55Metadata{D} = Metadata{<:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}, D}
 const JRA55Metadatum   = Metadatum{<:Union{<:JRA55MultipleYears, <:JRA55RepeatYear}}
 
 default_download_directory(::Union{<:JRA55MultipleYears, <:JRA55RepeatYear}) = download_JRA55_cache

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -2,7 +2,7 @@ using CFTime
 using Dates
 using Base: @propagate_inbounds
 
-struct Metadata{D, V}
+struct Metadata{V, D}
     name  :: Symbol
     dates :: D
     dataset :: V
@@ -39,7 +39,7 @@ function Metadata(variable_name;
 end
 
 const AnyDateTime = Union{AbstractCFDateTime, Dates.AbstractDateTime}
-const Metadatum   = Metadata{<:AnyDateTime}
+const Metadatum   = Metadata{<:Any, <:AnyDateTime}
 
 """
     Metadatum(variable_name;

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -38,8 +38,8 @@ function Metadata(variable_name;
     return Metadata(variable_name, dates, dataset, dir)
 end
 
-const AnyDateTime = Union{AbstractCFDateTime, Dates.AbstractDateTime}
-const Metadatum   = Metadata{<:Any, <:AnyDateTime}
+const AnyDateTime  = Union{AbstractCFDateTime, Dates.AbstractDateTime}
+const Metadatum{V} = Metadata{V, <:AnyDateTime} where V
 
 """
     Metadatum(variable_name;

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -67,8 +67,8 @@ download_dataset(metadata) = nothing
 Base.show(io::IO, metadata::Metadata) =
     print(io, "ECCOMetadata:", '\n',
     "├── name: $(metadata.name)", '\n',
-    "├── dates: $(metadata.dates)", '\n',
     "├── dataset: $(metadata.dataset)", '\n',
+    "├── dates: $(metadata.dates)", '\n',
     "└── data directory: $(metadata.dir)")
 
 # Treat Metadata as an array to allow iteration over the dates.
@@ -78,13 +78,13 @@ Base.eltype(metadata::Metadata) = Base.eltype(metadata.dates)
 # If only one date, it's a single element array
 Base.length(metadata::Metadatum) = 1
 
-@propagate_inbounds Base.getindex(m::Metadata, i::Int) = Metadata(m.name, m.dates[i],   m.dataset, m.dir)
-@propagate_inbounds Base.first(m::Metadata)            = Metadata(m.name, m.dates[1],   m.dataset, m.dir)
-@propagate_inbounds Base.last(m::Metadata)             = Metadata(m.name, m.dates[end], m.dataset, m.dir)
+@propagate_inbounds Base.getindex(m::Metadata, i::Int) = Metadata(m.name, m.dataset, m.dates[i],   m.dir)
+@propagate_inbounds Base.first(m::Metadata)            = Metadata(m.name, m.dataset, m.dates[1],   m.dir)
+@propagate_inbounds Base.last(m::Metadata)             = Metadata(m.name, m.dataset, m.dates[end], m.dir)
 
 @inline function Base.iterate(m::Metadata, i=1)
     if (i % UInt) - 1 < length(m)
-        return Metadata(m.name, m.dates[i], m.dataset, m.dir), i + 1
+        return Metadata(m.name, m.dataset, m.dates[i], m.dir), i + 1
     else
         return nothing
     end

--- a/src/DataWrangling/metadata.jl
+++ b/src/DataWrangling/metadata.jl
@@ -4,8 +4,8 @@ using Base: @propagate_inbounds
 
 struct Metadata{V, D}
     name  :: Symbol
-    dates :: D
     dataset :: V
+    dates :: D
     dir :: String
 end
 
@@ -35,7 +35,7 @@ function Metadata(variable_name;
                   dates=all_dates(dataset, variable_name)[1:1],
                   dir=default_download_directory(dataset))
 
-    return Metadata(variable_name, dates, dataset, dir)
+    return Metadata(variable_name, dataset, dates, dir)
 end
 
 const AnyDateTime  = Union{AbstractCFDateTime, Dates.AbstractDateTime}
@@ -55,7 +55,7 @@ function Metadatum(variable_name;
                    dir=default_download_directory(dataset))
 
     # TODO: validate that `date` is actually a single date?
-    return Metadata(variable_name, date, dataset, dir)
+    return Metadata(variable_name, dataset, date, dir)
 end
 
 # Just the current directory


### PR DESCRIPTION
This PR switches the type parameter of `Metadata` from `Metadata{D, V}` to `Metadata{V, D}` where `D` is the dates type and `V` is the dataset type

it makes more sense to have the `dataset` being the first parameter in the `Metadata` type since it is required much more than the dates to dispatch.

This PR is propedeutic to #437 