### PR TITLE
Change default backend for a `JRA55PrescribedAtmosphere`

### DIFF
--- a/src/DataWrangling/JRA55/JRA55_field_time_series.jl
+++ b/src/DataWrangling/JRA55/JRA55_field_time_series.jl
@@ -318,8 +318,14 @@ function JRA55FieldTimeSeries(metadata::JRA55Metadata, architecture=CPU(), FT=Fl
     download_dataset(metadata)
 
     # Regularize the backend in case of `JRA55NetCDFBackend`
-    if backend isa JRA55NetCDFBackend && backend.metadata isa Nothing
-        backend = JRA55NetCDFBackend(backend.length, metadata)
+    if backend isa JRA55NetCDFBackend 
+        if backend.metadata isa Nothing
+            backend = JRA55NetCDFBackend(backend.length, metadata)
+        end
+
+        if backend.length > length(metadata)
+            backend = JRA55NetCDFBackend(backend.start, length(metadata), metadata)
+        end
     end
 
     # Unpack metadata details

--- a/src/DataWrangling/JRA55/JRA55_prescribed_atmosphere.jl
+++ b/src/DataWrangling/JRA55/JRA55_prescribed_atmosphere.jl
@@ -23,7 +23,7 @@ function JRA55PrescribedAtmosphere(architecture = CPU(), FT = Float32;
                                    dataset = RepeatYearJRA55(),
                                    start_date = first_date(dataset, :temperature),
                                    end_date = last_date(dataset, :temperature),
-                                   backend = InMemory(),
+                                   backend = JRA55NetCDFBackend(10),
                                    time_indexing = Cyclical(),
                                    surface_layer_height = 10,  # meters
                                    include_rivers_and_icebergs = false,


### PR DESCRIPTION
to avoid loading a huge atmosphere in memory