### PR TITLE
Change default gustiness to 1

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -58,10 +58,10 @@ end
 
 """
     SimilarityTheoryFluxes(FT::DataType = Float64;
-                           gravitational_acceleration = convert(FT, 9.81),
-                           von_karman_constant = convert(FT, 0.4),
-                           turbulent_prandtl_number = convert(FT, 1),
-                           gustiness_parameter = convert(FT, 6.5),
+                           gravitational_acceleration = 9.81,
+                           von_karman_constant = 0.4,
+                           turbulent_prandtl_number = 1,
+                           gustiness_parameter = 0,
                            stability_functions = default_stability_functions(FT),
                            roughness_lengths = default_roughness_lengths(FT),
                            similarity_form = LogarithmicSimilarityProfile(),
@@ -77,7 +77,7 @@ Keyword Arguments
 
 - `von_karman_constant`: The von Karman constant. Default: 0.4.
 - `turbulent_prandtl_number`: The turbulent Prandtl number. Default: 1.
-- `gustiness_parameter`: The gustiness parameter that accounts for low wind speed areas. Default: 6.5.
+- `gustiness_parameter`: Increases surface fluxes in low wind conditions. Default: 0.
 - `stability_functions`: The stability functions. Default: `default_stability_functions(FT)` that follow the
                          formulation of Edson et al. (2013).
 - `roughness_lengths`: The roughness lengths used to calculate the characteristic scales for momentum, temperature and
@@ -90,7 +90,7 @@ Keyword Arguments
 function SimilarityTheoryFluxes(FT::DataType = Oceananigans.defaults.FloatType;
                                 von_karman_constant = 0.4,
                                 turbulent_prandtl_number = 1,
-                                gustiness_parameter = 6.5,
+                                gustiness_parameter = 0,
                                 stability_functions = edson_stability_functions(FT),
                                 roughness_lengths = default_roughness_lengths(FT),
                                 similarity_form = LogarithmicSimilarityProfile(),

--- a/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -90,7 +90,7 @@ Keyword Arguments
 function SimilarityTheoryFluxes(FT::DataType = Oceananigans.defaults.FloatType;
                                 von_karman_constant = 0.4,
                                 turbulent_prandtl_number = 1,
-                                gustiness_parameter = 0,
+                                gustiness_parameter = 1,
                                 stability_functions = edson_stability_functions(FT),
                                 roughness_lengths = default_roughness_lengths(FT),
                                 similarity_form = LogarithmicSimilarityProfile(),

--- a/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -61,7 +61,7 @@ end
                            gravitational_acceleration = 9.81,
                            von_karman_constant = 0.4,
                            turbulent_prandtl_number = 1,
-                           gustiness_parameter = 0,
+                           gustiness_parameter = 1,
                            stability_functions = default_stability_functions(FT),
                            roughness_lengths = default_roughness_lengths(FT),
                            similarity_form = LogarithmicSimilarityProfile(),

--- a/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -77,7 +77,7 @@ Keyword Arguments
 
 - `von_karman_constant`: The von Karman constant. Default: 0.4.
 - `turbulent_prandtl_number`: The turbulent Prandtl number. Default: 1.
-- `gustiness_parameter`: Increases surface fluxes in low wind conditions. Default: 0.
+- `gustiness_parameter`: Increases surface fluxes in low wind conditions. Default: 1.
 - `stability_functions`: The stability functions. Default: `default_stability_functions(FT)` that follow the
                          formulation of Edson et al. (2013).
 - `roughness_lengths`: The roughness lengths used to calculate the characteristic scales for momentum, temperature and

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -371,7 +371,7 @@ end
     PrescribedAtmosphere(grid, times;
                          clock = Clock{Float64}(time = 0),
                          surface_layer_height = 10, # meters
-                         boundary_layer_height = 600 # meters,
+                         boundary_layer_height = 0 # meters,
                          thermodynamics_parameters = PrescribedAtmosphereThermodynamicsParameters(FT),
                          auxiliary_freshwater_flux = nothing,
                          velocities            = default_atmosphere_velocities(grid, times),
@@ -385,8 +385,8 @@ state with data given at `times`.
 """
 function PrescribedAtmosphere(grid, times;
                               clock = Clock{Float64}(time = 0),
-                              surface_layer_height = convert(eltype(grid), 10),
-                              boundary_layer_height = convert(eltype(grid), 600),
+                              surface_layer_height = 10,
+                              boundary_layer_height = 0,
                               thermodynamics_parameters = nothing,
                               auxiliary_freshwater_flux = nothing,
                               velocities            = default_atmosphere_velocities(grid, times),
@@ -399,6 +399,9 @@ function PrescribedAtmosphere(grid, times;
     if isnothing(thermodynamics_parameters)
         thermodynamics_parameters = PrescribedAtmosphereThermodynamicsParameters(FT)
     end
+
+    boundary_layer_height = convert(FT, boundary_layer_height)
+    surface_layer_height = convert(FT, surface_layer_height)
 
     return PrescribedAtmosphere(grid,
                                 clock,

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -386,7 +386,7 @@ state with data given at `times`.
 function PrescribedAtmosphere(grid, times;
                               clock = Clock{Float64}(time = 0),
                               surface_layer_height = 10,
-                              boundary_layer_height = 0,
+                              boundary_layer_height = 512,
                               thermodynamics_parameters = nothing,
                               auxiliary_freshwater_flux = nothing,
                               velocities            = default_atmosphere_velocities(grid, times),

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -343,6 +343,8 @@ function default_freshwater_flux(grid, times)
     return (; rain, snow)
 end
 
+""" The standard unit of atmospheric pressure; 1 standard atmosphere (atm) = 101,325 Pascals (Pa) in SI units.
+This is approximately equal to the mean sea-level atmospheric pressure on Earth. """
 function default_atmosphere_pressure(grid, times)
     pa = FieldTimeSeries{Center, Center, Nothing}(grid, times)
     parent(pa) .= 101325
@@ -422,7 +424,7 @@ end
 """
     TwoBandDownwellingRadiation(shortwave=nothing, longwave=nothing)
 
-Return a two-band model for downwelling radiation (split in a shortwave band
+Return a two-band model for downwelling radiation (split into a shortwave band
 and a longwave band) that passes through the atmosphere and arrives at the surface of ocean
 or sea ice.
 """
@@ -434,4 +436,3 @@ Adapt.adapt_structure(to, tsdr::TwoBandDownwellingRadiation) =
                                 adapt(to, tsdr.longwave))
 
 end # module
-

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -400,9 +400,6 @@ function PrescribedAtmosphere(grid, times;
         thermodynamics_parameters = PrescribedAtmosphereThermodynamicsParameters(FT)
     end
 
-    boundary_layer_height = convert(FT, boundary_layer_height)
-    surface_layer_height = convert(FT, surface_layer_height)
-
     return PrescribedAtmosphere(grid,
                                 clock,
                                 velocities,

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -371,7 +371,7 @@ end
     PrescribedAtmosphere(grid, times;
                          clock = Clock{Float64}(time = 0),
                          surface_layer_height = 10, # meters
-                         boundary_layer_height = 0 # meters,
+                         boundary_layer_height = 512 # meters,
                          thermodynamics_parameters = PrescribedAtmosphereThermodynamicsParameters(FT),
                          auxiliary_freshwater_flux = nothing,
                          velocities            = default_atmosphere_velocities(grid, times),


### PR DESCRIPTION
The value 6.5 seems to cause a large overestimation of the momentum flux and in turn, the heat and vapor fluxes as well.

In a simple example which I might get to post later, changing this to 0 caused the momentum flux to divide by 3.

cc @simone-silvestri 

Note Fairall et al 1996 report values in the 1-1.2 range:

<img width="901" alt="image" src="https://github.com/user-attachments/assets/cc6dc44e-e749-4f93-859d-99296ce1d6e6" />

An alternative model for "low wind speed" is to simply cap the minimum velocity difference at some constant value like 0.5 m/s, eg

https://cosima.org.au/wp-content/uploads/2025/01/ACCESS-OM2-1-025-010deg-2025-01-24-7be8a1c.pdf#page=30.16

@navidcy and I propose to move this parameterization, and other "wind speed" parameterizations, so the `velocity_formulation` object eg in `WindVelocity` and `RelativeVelocity`:

https://github.com/CliMA/ClimaOcean.jl/blob/740c779435ee736aeabfdcfa303fb40ea3f7a93f/src/OceanSeaIceModels/InterfaceComputations/interface_states.jl#L106-L110