### PR TITLE
Better interpolation info shown to user

### DIFF
--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -121,7 +121,7 @@ function regrid_bathymetry(target_grid;
                            dir = download_bathymetry_cache,
                            url = etopo_url,
                            filename = "ETOPO_2022_v1_60s_N90W180_surface.nc",
-                           interpolation_passes = 1,
+                           smoothing = InterpolationPasses(0),
                            major_basins = 1) # Allow an `Inf` number of "lakes"
 
     if isinteger(interpolation_passes)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -265,10 +265,10 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     old_z  = native_z
     TX, TY = topology(target_grid)
 
+    @info "Interpolation passes of bathymetry size $(size(old_z)) onto a $gridtype target grid of size $Nt:"
     for pass = 1:passes - 1
         new_size = (Nλ[pass], Nφ[pass], 1)
-
-        @info "Bathymetry extra interpolation pass $pass with size $new_size"
+        @info "    pass $pass to size $new_size"
 
         new_grid = LatitudeLongitudeGrid(architecture(target_grid), Float32,
                                          size = new_size,
@@ -283,7 +283,8 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
         old_z = new_z
     end
 
-    @info "Interpolating bathymetry of size $Nn onto a $gridtype target grid of size $Nt"
+    new_size = (Nλ[passes], Nφ[passes], 1)
+    @info "    pass $passes to size $new_size"
     target_z = Field{Center, Center, Nothing}(target_grid)
     interpolate!(target_z, old_z)
 

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -216,7 +216,8 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
 
         gridtype = target_grid isa TripolarGrid ? "TripolarGrid" :
                    target_grid isa LatitudeLongitudeGrid ? "LatitudeLongitudeGrid" :
-                   target_grid isa RectilinearGrid ? "RectilinearGrid" : error("unknown type of target grid")
+                   target_grid isa RectilinearGrid ? "RectilinearGrid" :
+                   error("unknown target grid type")
 
         @info "Interpolating bathymetry onto a $gridtype target grid of size $(size(target_grid))"
         interpolate!(target_z, native_z)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -217,35 +217,10 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     Nλt, Nφt = Nt = size(target_grid)
     Nλn, Nφn = Nn = size(native_z)
 
-    resxt = minimum_xspacing(target_grid)
-    resyt = minimum_yspacing(target_grid)
-
-    resxn = minimum_xspacing(native_z.grid)
-    resyn = minimum_yspacing(native_z.grid)
-
-    # Check whether we are refining the grid in any directions.
-    # If so, skip interpolation passes, as they are not needed.
-    if resxt < resxn || resyt < resyn
-        target_z = Field{Center, Center, Nothing}(target_grid)
-
+    if passes == 1
         @info "Interpolating bathymetry of size $Nn onto a $gridtype target grid of size $Nt"
+        target_z = Field{Center, Center, Nothing}(target_grid)
         interpolate!(target_z, native_z)
-
-        if passes > 0
-            passes_str = passes == 1 ? "1 interpolation pass" : "$passes interpolation passes"
-
-            @info string("Skipping extra $passes_str for bathymetry.", '\n',
-                        "Extra interpolation passes may only be used to coarsen bathymetry", '\n',
-                        "and require that the bathymetry is finer than the target grid in", '\n',
-                        "both horizontal directions.", '\n',
-                        "Grid info:", '\n',
-                        "target grid", '\n',
-                        "├── minimum x-spacings ", @sprintf("%.3e", resxt), " m", '\n',
-                        "└── minimum x-spacings ", @sprintf("%.3e", resyt), " m", '\n',
-                        "bathymetry grid", '\n',
-                        "├── minimum x-spacings ", @sprintf("%.3e", resxn), " m", '\n',
-                        "└── minimum x-spacings ", @sprintf("%.3e", resyn), " m")
-        end
         return target_z
     end
 
@@ -265,10 +240,10 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     old_z  = native_z
     TX, TY = topology(target_grid)
 
-    @info "Interpolation passes of bathymetry size $(size(old_z)) onto a $gridtype target grid of size $Nt:"
+    @info "Interpolating bathymetry of size $(size(old_z)) onto a $gridtype target grid of size $Nt"
     for pass = 1:passes - 1
         new_size = (Nλ[pass], Nφ[pass], 1)
-        @info "    pass $pass to size $new_size"
+        @info "    interpolation pass $pass to size $new_size"
 
         new_grid = LatitudeLongitudeGrid(architecture(target_grid), Float32,
                                          size = new_size,
@@ -284,7 +259,7 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     end
 
     new_size = (Nλ[passes], Nφ[passes], 1)
-    @info "    pass $passes to size $new_size"
+    @info "    interpolation pass $passes to size $new_size"
     target_z = Field{Center, Center, Nothing}(target_grid)
     interpolate!(target_z, old_z)
 

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -209,9 +209,6 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     resxn = minimum_xspacing(native_z.grid)
     resyn = minimum_yspacing(native_z.grid)
 
-    resxt < resxn
-    resyt < resyn
-
     # Check whether we are refining the grid in any directions.
     # If so, skip interpolation passes, as they are not needed.
     if resxt < resxn || resyt < resyn

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -217,10 +217,35 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     Nλt, Nφt = Nt = size(target_grid)
     Nλn, Nφn = Nn = size(native_z)
 
-    if passes == 1
-        @info "Interpolating bathymetry of size $Nn onto a $gridtype target grid of size $Nt"
+    resxt = minimum_xspacing(target_grid)
+    resyt = minimum_yspacing(target_grid)
+
+    resxn = minimum_xspacing(native_z.grid)
+    resyn = minimum_yspacing(native_z.grid)
+
+    # Check whether we are refining the grid in any directions.
+    # If so, skip interpolation passes, as they are not needed.
+    if resxt < resxn || resyt < resyn
         target_z = Field{Center, Center, Nothing}(target_grid)
+
+        @info "Interpolating bathymetry of size $Nn onto a $gridtype target grid of size $Nt"
         interpolate!(target_z, native_z)
+
+        if passes > 0
+            passes_str = passes == 1 ? "1 interpolation pass" : "$passes interpolation passes"
+
+            @info string("Skipping extra $passes_str for bathymetry.", '\n',
+                        "Extra interpolation passes may only be used to coarsen bathymetry", '\n',
+                        "and require that the bathymetry is finer than the target grid in", '\n',
+                        "both horizontal directions.", '\n',
+                        "Grid info:", '\n',
+                        "target grid", '\n',
+                        "├── minimum x-spacings ", @sprintf("%.3e", resxt), " m", '\n',
+                        "└── minimum x-spacings ", @sprintf("%.3e", resyt), " m", '\n',
+                        "bathymetry grid", '\n',
+                        "├── minimum x-spacings ", @sprintf("%.3e", resxn), " m", '\n',
+                        "└── minimum x-spacings ", @sprintf("%.3e", resyn), " m")
+        end
         return target_z
     end
 
@@ -240,10 +265,10 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     old_z  = native_z
     TX, TY = topology(target_grid)
 
-    @info "Interpolating bathymetry of size $(size(old_z)) onto a $gridtype target grid of size $Nt"
+    @info "Interpolation passes of bathymetry size $(size(old_z)) onto a $gridtype target grid of size $Nt:"
     for pass = 1:passes - 1
         new_size = (Nλ[pass], Nφ[pass], 1)
-        @info "    interpolation pass $pass to size $new_size"
+        @info "    pass $pass to size $new_size"
 
         new_grid = LatitudeLongitudeGrid(architecture(target_grid), Float32,
                                          size = new_size,
@@ -259,7 +284,7 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     end
 
     new_size = (Nλ[passes], Nφ[passes], 1)
-    @info "    interpolation pass $passes to size $new_size"
+    @info "    pass $passes to size $new_size"
     target_z = Field{Center, Center, Nothing}(target_grid)
     interpolate!(target_z, old_z)
 

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -121,7 +121,7 @@ function regrid_bathymetry(target_grid;
                            dir = download_bathymetry_cache,
                            url = etopo_url,
                            filename = "ETOPO_2022_v1_60s_N90W180_surface.nc",
-                           smoothing = InterpolationPasses(0),
+                           interpolation_passes = 1,
                            major_basins = 1) # Allow an `Inf` number of "lakes"
 
     if isinteger(interpolation_passes)

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -124,6 +124,14 @@ function regrid_bathymetry(target_grid;
                            interpolation_passes = 1,
                            major_basins = 1) # Allow an `Inf` number of "lakes"
 
+    if isinteger(interpolation_passes)
+        interpolation_passes = convert(Int, interpolation_passes)
+    end
+
+    if interpolation_passes isa Nothing || !isa(interpolation_passes, Int) || interpolation_passes ≤ 0
+        return throw(ArgumentError("interpolation_passes has to be an integer ≥ 1"))
+    end
+
     filepath = download_bathymetry(; url, dir, filename)
     dataset = Dataset(filepath, "r")
 
@@ -200,10 +208,6 @@ end
 # Here we can either use `regrid!` (three dimensional version) or `interpolate!`.
 function interpolate_bathymetry_in_passes(native_z, target_grid;
                                           passes = 10)
-
-    if passes isa Nothing || passes == 0
-        return throw(ArgumentError("interpolation_passes has to be an integer ≥ 1"))
-    end
 
     gridtype = target_grid isa TripolarGrid ? "TripolarGrid" :
                target_grid isa LatitudeLongitudeGrid ? "LatitudeLongitudeGrid" :

--- a/src/Bathymetry.jl
+++ b/src/Bathymetry.jl
@@ -230,8 +230,13 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
                         "Extra interpolation passes may only be used to coarsen bathymetry", '\n',
                         "and require that the bathymetry is finer than the target grid in", '\n',
                         "both horizontal directions.", '\n',
-                        "minimum x-spacings: target grid ", @sprintf("%.3e", resxt), " m; bathymetry grid ", @sprintf("%.3e", resxn), " m", '\n',
-                        "minimum y-spacings: target grid ", @sprintf("%.3e", resyt), " m; bathymetry grid ", @sprintf("%.3e", resyn), " m")
+                        "Grid info:", '\n',
+                        "target grid", '\n',
+                        "├── minimum x-spacings ", @sprintf("%.3e", resxt), " m", '\n',
+                        "└── minimum x-spacings ", @sprintf("%.3e", resyt), " m", '\n',
+                        "bathymetry grid", '\n',
+                        "├── minimum x-spacings ", @sprintf("%.3e", resxn), " m", '\n',
+                        "└── minimum x-spacings ", @sprintf("%.3e", resyn), " m")
         end
         return target_z
     end

--- a/test/test_bathymetry.jl
+++ b/test/test_bathymetry.jl
@@ -1,3 +1,5 @@
+include("runtests_setup.jl")
+
 using Oceananigans
 using Statistics
 using ClimaOcean
@@ -26,10 +28,10 @@ using ClimaOcean.Bathymetry: remove_minor_basins!
         # Test that remove_minor_basins!(Z, 2) remove the correct number of Basins
         bottom_height = Field{Center, Center, Nothing}(grid)
         control_bottom_height = Field{Center, Center, Nothing}(grid)
-        
-        # A two basins bathymetry
+
+        # A two-basins bathymetry
         bottom(x, y) = - 1000 * Int((x < 10) | (x > 50))
-        
+
         set!(bottom_height, bottom)
         set!(control_bottom_height, bottom)
 
@@ -39,12 +41,12 @@ using ClimaOcean.Bathymetry: remove_minor_basins!
 
         # This should have removed the left basin
         remove_minor_basins!(bottom_height, 1)
-        
-        # The remaning bottom cells that are not immersed should be only on the right hand side
+
+        # The remaining bottom cells that are not immersed should be only on the right hand side
         # The left half of the domain should be fully immersed, i.e., bottom == 0
         @test sum(view(bottom_height, 1:50, :, 1)) == 0
 
-        # While the right side should be not immersed, with a mean bottom depth 
+        # While the right side should be not immersed, with a mean bottom depth
         # of -1000 meters
         @test mean(view(bottom_height, 51:100, :, 1)) == -1000
 


### PR DESCRIPTION
Closes #476

Also gives more informative message to the user regarding why the extra interpolation passes are skipped.

```Julia
using ClimaOcean
using Oceananigans

underlying_grid = TripolarGrid(size = (360, 180, 50),
                               z = (-5000, 0),
                               halo = (5, 5, 4),
                               first_pole_longitude = 70,
                               north_poles_latitude = 55)
```
```Julia
bottom_height = regrid_bathymetry(underlying_grid;
                                  major_basins = 2)
[ Info: Interpolating bathymetry of size (21600, 10800, 1) onto a TripolarGrid target grid of size (360, 180, 50)
360×180×1 Field{Center, Center, Nothing} reduced over dims = (3,) on OrthogonalSphericalShellGrid on CPU
├── grid: 360×180×50 OrthogonalSphericalShellGrid{Float64, Periodic, Oceananigans.Grids.RightConnected, Bounded} on CPU with 5×5×4 halo and with precomputed metrics
├── boundary conditions: FieldBoundaryConditions
│   └── west: Periodic, east: Periodic, south: ZeroFlux, north: Zipper, bottom: Nothing, top: Nothing, immersed: Default
└── data: 370×190×1 OffsetArray(::Array{Float64, 3}, -4:365, -4:185, 1:1) with eltype Float64 with indices -4:365×-4:185×1:1
    └── max=6102.41, min=-9452.9, mean=-1960.54
```
```Julia
bottom_height_with_extra_passes = regrid_bathymetry(underlying_grid;
                                                    interpolation_passes = 6,
                                                    major_basins = 2)
[ Info: Interpolation passes of bathymetry size (21600, 10800, 1) onto a TripolarGrid target grid of size (360, 180, 50):
[ Info:     pass 1 to size (18060, 9030, 1)
[ Info:     pass 2 to size (14520, 7260, 1)
[ Info:     pass 3 to size (10980, 5490, 1)
[ Info:     pass 4 to size (7440, 3720, 1)
[ Info:     pass 5 to size (3900, 1950, 1)
[ Info:     pass 6 to size (360, 180, 1)
360×180×1 Field{Center, Center, Nothing} reduced over dims = (3,) on OrthogonalSphericalShellGrid on CPU
├── grid: 360×180×50 OrthogonalSphericalShellGrid{Float64, Periodic, Oceananigans.Grids.RightConnected, Bounded} on CPU with 5×5×4 halo and with precomputed metrics
├── boundary conditions: FieldBoundaryConditions
│   └── west: Periodic, east: Periodic, south: ZeroFlux, north: Zipper, bottom: Nothing, top: Nothing, immersed: Default
└── data: 370×190×1 OffsetArray(::Array{Float64, 3}, -4:365, -4:185, 1:1) with eltype Float64 with indices -4:365×-4:185×1:1
    └── max=6005.79, min=-9210.06, mean=-1960.37
```

cc @taimoorsohail 