### PR TITLE
Rework radiative properties

### DIFF
--- a/src/ClimaOcean.jl
+++ b/src/ClimaOcean.jl
@@ -59,15 +59,15 @@ const SKOFTS = SomeKindOfFieldTimeSeries
     return a(λ, φ, z, time)
 end
 
-@inline function stateindex(a::Tuple, i, j, k, grid, time)
+@inline function stateindex(a::Tuple, i, j, k, grid, time, args...)
     N = length(a)
     ntuple(Val(N)) do n
-        stateindex(a[n], i, j, k, grid, time)
+        stateindex(a[n], i, j, k, grid, time, args...)
     end
 end
 
-@inline function stateindex(a::NamedTuple, i, j, k, grid, time)
-    vals = stateindex(values(a), i, j, k, grid, time)
+@inline function stateindex(a::NamedTuple, i, j, k, grid, time, args...)
+    vals = stateindex(values(a), i, j, k, grid, time, args...)
     names = keys(a)
     return NamedTuple{names}(vals)
 end

--- a/src/ClimaOcean.jl
+++ b/src/ClimaOcean.jl
@@ -53,8 +53,7 @@ const SKOFTS = SomeKindOfFieldTimeSeries
 @inline stateindex(a::AbstractArray, i, j, k, args...) = @inbounds a[i, j, k]
 @inline stateindex(a::SKOFTS, i, j, k, grid, time, args...) = @inbounds a[i, j, k, time]
 
-@inline function stateindex(a::Function, i, j, k, grid, time, loc)
-    LX, LY, LZ = loc
+@inline function stateindex(a::Function, i, j, k, grid, time, (LX, LY, LZ), args...)
     λ, φ, z = node(i, j, k, grid, LX(), LY(), LZ())
     return a(λ, φ, z, time)
 end

--- a/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
@@ -102,7 +102,7 @@ end
     σ = atmos_ocean_properties.radiation.σ
     α = atmos_ocean_properties.radiation.α
     ϵ = atmos_ocean_properties.radiation.ϵ
-    Qu  = upwelling_radiation(i, j, kᴺ, grid, time, T, σ, ϵ) 
+    Qu  = upwelling_radiation(i, j, kᴺ, grid, time, Tₛ, σ, ϵ) 
     Qdℓ = downwelling_longwave_radiation(i, j, kᴺ, grid, time, ϵ, Qℓ)
     Qds = downwelling_shortwave_radiation(i, j, kᴺ, grid, time, α, Qs)
     ΣQao = Qu + Qc + Qv + Qdℓ + Qds

--- a/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
@@ -247,7 +247,7 @@ end
     σ = atmos_sea_ice_properties.radiation.σ
     α = atmos_sea_ice_properties.radiation.α
     ϵ = atmos_sea_ice_properties.radiation.ϵ
-    Qu = upwelling_radiation(i, j, kᴺ, grid, time, T, σ, ϵ) 
+    Qu = upwelling_radiation(i, j, kᴺ, grid, time, Ts, σ, ϵ) 
     Qd = net_downwelling_radiation(i, j, kᴺ, grid, time, α, ϵ, Qs, Qℓ)
 
     ΣQt = (Qd + Qu + Qc + Qv) * ℵi # If ℵi == 0 there is no heat flux from the top!

--- a/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
@@ -100,11 +100,11 @@ end
 
     # Compute radiation fluxes
     σ = atmos_ocean_properties.radiation.σ
-    α = stateindex(atmos_ocean_properties.radiation.α, i, j, kᴺ, grid, time)
-    ϵ = stateindex(atmos_ocean_properties.radiation.ϵ, i, j, kᴺ, grid, time)
-    Qu = upwelling_radiation(Tₛ, σ, ϵ)
-    Qdℓ = downwelling_longwave_radiation(Qℓ, ϵ)
-    Qds = downwelling_shortwave_radiation(Qs, α)
+    α = atmos_ocean_properties.radiation.α
+    ϵ = atmos_ocean_properties.radiation.ϵ
+    Qu  = upwelling_radiation(i, j, kᴺ, grid, time, T, σ, ϵ) 
+    Qdℓ = downwelling_longwave_radiation(i, j, kᴺ, grid, time, ϵ, Qℓ)
+    Qds = downwelling_shortwave_radiation(i, j, kᴺ, grid, time, α, Qs)
     ΣQao = Qu + Qc + Qv + Qdℓ + Qds
 
     @inbounds begin
@@ -245,10 +245,10 @@ end
 
     # Compute radiation fluxes
     σ = atmos_sea_ice_properties.radiation.σ
-    α = stateindex(atmos_sea_ice_properties.radiation.α, i, j, kᴺ, grid, time)
-    ϵ = stateindex(atmos_sea_ice_properties.radiation.ϵ, i, j, kᴺ, grid, time)
-    Qu = upwelling_radiation(Ts, σ, ϵ)
-    Qd = net_downwelling_radiation(i, j, grid, time, α, ϵ, Qs, Qℓ)
+    α = atmos_sea_ice_properties.radiation.α
+    ϵ = atmos_sea_ice_properties.radiation.ϵ
+    Qu = upwelling_radiation(i, j, kᴺ, grid, time, T, σ, ϵ) 
+    Qd = net_downwelling_radiation(i, j, kᴺ, grid, time, α, ϵ, Qs, Qℓ)
 
     ΣQt = (Qd + Qu + Qc + Qv) * ℵi # If ℵi == 0 there is no heat flux from the top!
     ΣQb = Qf + Qi

--- a/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -122,6 +122,16 @@ end
     needs_to_converge = stop_criteria isa ConvergenceStopCriteria
     not_water = inactive_node(i, j, kᴺ, grid, Center(), Center(), Center())
 
+    # Compute local radiative properties and rebuild the interface properties
+    α = stateindex(interface_properties.α, i, j, kᴺ, grid, time, (Center, Center, Center), Qs)
+    ϵ = stateindex(interface_properties.ϵ, i, j, kᴺ, grid, time, (Center, Center, Center))
+    σ = interface_properties.radiation.σ
+
+    interface_properties = InterfaceProperties((; α, ϵ, σ),
+                                               interface_properties.specific_humidity_formulation,
+                                               interface_properties.temperature_formulation,
+                                               interface_properties.velocity_formulation)
+
     if needs_to_converge && not_water
         interface_state = zero_interface_state(FT)
     else

--- a/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -123,8 +123,8 @@ end
     not_water = inactive_node(i, j, kᴺ, grid, Center(), Center(), Center())
 
     # Compute local radiative properties and rebuild the interface properties
-    α = stateindex(interface_properties.α, i, j, kᴺ, grid, time, (Center, Center, Center), Qs)
-    ϵ = stateindex(interface_properties.ϵ, i, j, kᴺ, grid, time, (Center, Center, Center))
+    α = stateindex(interface_properties.radiation.α, i, j, kᴺ, grid, time, (Center, Center, Center), Qs)
+    ϵ = stateindex(interface_properties.radiation.ϵ, i, j, kᴺ, grid, time, (Center, Center, Center))
     σ = interface_properties.radiation.σ
 
     interface_properties = InterfaceProperties((; α, ϵ, σ),

--- a/src/OceanSeaIceModels/InterfaceComputations/interface_states.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/interface_states.jl
@@ -299,8 +299,10 @@ end
     ϵ = interface_properties.radiation.ϵ
     α = interface_properties.radiation.α
 
+    Qs = downwelling_radiation.Qs
+    Qℓ = downwelling_radiation.Qℓ
     Qu = upwelling_radiation(Tₛ⁻, σ, ϵ)
-    Qd = net_downwelling_radiation(downwelling_radiation, α, ϵ)
+    Qd = net_downwelling_radiation(Qs, Qℓ, α, ϵ)
 
     u★ = interface_state.u★
     θ★ = interface_state.θ★

--- a/src/OceanSeaIceModels/InterfaceComputations/latitude_dependent_albedo.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/latitude_dependent_albedo.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Grids: ηnode
+using Oceananigans.Fields: instantiate
 
 struct LatitudeDependentAlbedo{FT}
     direct :: FT
@@ -45,8 +46,8 @@ end
 
 Base.show(io::IO, α::LatitudeDependentAlbedo) = print(io, summary(α))
 
-@inline function stateindex(α::LatitudeDependentAlbedo, i, j, k, grid, time)
-    φ = ηnode(i, j, k, grid, Center(), Center(), Center())
+@inline function stateindex(α::LatitudeDependentAlbedo, i, j, k, grid, time, loc, args...)
+    φ = ηnode(i, j, k, grid, instantiate.(loc))
     α₀ = α.diffuse
     α₁ = α.direct
     return α₀ - α₁ * hack_cosd(2φ)

--- a/src/OceanSeaIceModels/InterfaceComputations/latitude_dependent_albedo.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/latitude_dependent_albedo.jl
@@ -46,8 +46,8 @@ end
 
 Base.show(io::IO, α::LatitudeDependentAlbedo) = print(io, summary(α))
 
-@inline function stateindex(α::LatitudeDependentAlbedo, i, j, k, grid, time, loc, args...)
-    φ = ηnode(i, j, k, grid, instantiate.(loc))
+@inline function stateindex(α::LatitudeDependentAlbedo, i, j, k, grid, time, (LX, LY, LZ), args...)
+    φ = ηnode(i, j, k, grid, LX(), LY(), LZ())
     α₀ = α.diffuse
     α₁ = α.direct
     return α₀ - α₁ * hack_cosd(2φ)

--- a/src/OceanSeaIceModels/InterfaceComputations/radiation.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/radiation.jl
@@ -112,7 +112,8 @@ end
     downwelling_shortwave_radiation(i, j, k, grid, time, α, Qs) + 
     downwelling_longwave_radiation(i, j, k, grid, time, ϵ, Qℓ)
 
-# Inside the solver we lose the grid and time information 
+# Inside the solver we lose both spatial and temporal information, but the
+# radiative properties have already been computed correctly
 @inline net_downwelling_radiation(Qs, Qℓ, α, ϵ) = - (1 - α) * Qs - ϵ * Qℓ
 
 @inline upwelling_radiation(T, σ, ϵ) = σ * ϵ * T^4

--- a/src/OceanSeaIceModels/InterfaceComputations/tabulated_albedo.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/tabulated_albedo.jl
@@ -115,10 +115,9 @@ Base.show(io::IO, α::TabulatedAlbedo) = print(io, summary(α))
 @inline simulation_day(time::Time{<:Number})      = time.time ÷ 86400
 @inline seconds_in_day(time::Time{<:Number}, day) = time.time - day * 86400
 
-@inline function net_downwelling_radiation(i, j, grid, time, radiation::Radiation{<:Any, <:Any, <:SurfaceProperties{<:TabulatedAlbedo}}, Qs, Qℓ)
-    α = radiation.reflection.ocean
+@inline function stateindex(α::TabulatedAlbedo, i, j, k, grid, time, loc, Qs)
     FT = eltype(α)
-    λ, φ, z = _node(i, j, 1, grid, Center(), Center(), Center())
+    λ, φ, z = _node(i, j, k, grid, Center(), Center(), Center())
 
     φ = deg2rad(φ)
     λ = deg2rad(λ)
@@ -164,8 +163,6 @@ Base.show(io::IO, α::TabulatedAlbedo) = print(io, summary(α))
                    ϕ₃(ξ, η) * getindex(α.α_table, i⁺, j⁻) +
                    ϕ₄(ξ, η) * getindex(α.α_table, i⁺, j⁺)
 
-    ϵ = stateindex(radiation.emission.ocean, i, j, 1, grid, time)
-
-    return - (1 - α) * Qs - ϵ * Qℓ
+    return α
 end
 


### PR DESCRIPTION
In main we need to have local (spatial and temporal) information to evaluate possible space-time-dependent radiative properties inside the solver. As a consequence, `LatitudeDependentAlbedo` (and `TabulatedAlbedo` would not work in combination with a `SkinTemperature` formulation).

This PR reworks a bit the flow of information (in addition to fixing a bug in `stateindex`) to allow passing radiative properties which are functions.

and also reintroduces a method which was needed but deleted in #502 