### PR TITLE
Fix a bug in `Field(metadata)`

### DIFF
--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -57,6 +57,11 @@ function Field(metadata::Metadatum, arch=CPU();
                halo = (3, 3, 3),
                cache_inpainted_data = true)
 
+    # Make data available
+    download_dataset(metadata)
+    path = metadata_path(metadata)
+    dsname = dataset_variable_name(metadata)
+
     grid = native_grid(metadata, arch; halo)
     LX, LY, LZ = location(metadata)
     field = Field{LX, LY, LZ}(grid)
@@ -84,10 +89,6 @@ function Field(metadata::Metadatum, arch=CPU();
             close(file)
         end
     end
-
-    download_dataset(metadata)
-    path = metadata_path(metadata)
-    dsname = dataset_variable_name(metadata)
 
     # NetCDF shenanigans
     ds = Dataset(path)

--- a/src/DataWrangling/metadata_field.jl
+++ b/src/DataWrangling/metadata_field.jl
@@ -57,10 +57,8 @@ function Field(metadata::Metadatum, arch=CPU();
                halo = (3, 3, 3),
                cache_inpainted_data = true)
 
-    # Make data available
+    # Ensure data is available
     download_dataset(metadata)
-    path = metadata_path(metadata)
-    dsname = dataset_variable_name(metadata)
 
     grid = native_grid(metadata, arch; halo)
     LX, LY, LZ = location(metadata)
@@ -89,6 +87,9 @@ function Field(metadata::Metadatum, arch=CPU();
             close(file)
         end
     end
+
+    path = metadata_path(metadata)
+    dsname = dataset_variable_name(metadata)
 
     # NetCDF shenanigans
     ds = Dataset(path)


### PR DESCRIPTION
the `Field` constructor needs the donwloaded data for particular datasets (like Copernicus) to be able to build the `native_grid`. So the `download_dataset` should be performed before `native_grid`