### PR TITLE
Correct atmosphere - sea ice heat flux

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/assemble_net_fluxes.jl
@@ -282,7 +282,7 @@ end
     Qs = transmitted_shortwave_radiation(i, j, kᴺ, grid, time, α, Qs)
     Qℓ = absorbed_longwave_radiation(i, j, kᴺ, grid, time, ϵ, Qℓ)
 
-    ΣQt = (Qs + Qℓ + Qu + Qc + Qv) * ℵi # If ℵi == 0 there is no heat flux from the top!
+    ΣQt = (Qs + Qℓ + Qu + Qc + Qv) * (ℵi > 0) # If ℵi == 0 there is no heat flux from the top!
     ΣQb = Qf + Qi
 
     # Mask fluxes over land for convenience


### PR DESCRIPTION
We decided that this was the correct formulation but haven't changed the src code to reflect it yet. This change has already happened in [ClimaSeaIce](https://github.com/CliMA/ClimaSeaIce.jl/commit/0f2444add91738186f5a2c37d0886e9e7c3b6d1c) 