### PR TITLE
Increase Charnock parameter to see effect on example global simulations

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/roughness_lengths.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/roughness_lengths.jl
@@ -88,7 +88,7 @@ function MomentumRoughnessLength(FT=Oceananigans.defaults.FloatType;
                                  gravitational_acceleration = default_gravitational_acceleration,
                                  maximum_roughness_length = 1,
                                  air_kinematic_viscosity = 1.5e-5,
-                                 wave_formulation = 0.02,
+                                 wave_formulation = 0.04,
                                  smooth_wall_parameter = 0.11)
 
     if wave_formulation isa Number


### PR DESCRIPTION
This PR increases the Charnock parameter to explore its effect on global simulations and SST extrema. Once we have #540 we will have more diagnostics about SST/fluxes in the example which will further help diagnose how this changes the solution.