### PR TITLE
Change advection defaults

### DIFF
--- a/src/OceanSimulations/ocean_simulation.jl
+++ b/src/OceanSimulations/ocean_simulation.jl
@@ -82,7 +82,6 @@ default_vertical_coordinate(::MutableGridOfSomeKind) = Oceananigans.Models.ZStar
 function default_ocean_closure(FT=Oceananigans.defaults.FloatType)
     mixing_length = CATKEMixingLength(Cᵇ=0.01)
     turbulent_kinetic_energy_equation = CATKEEquation(Cᵂϵ=1.0)
-
     return CATKEVerticalDiffusivity(VerticallyImplicitTimeDiscretization(), FT; mixing_length, turbulent_kinetic_energy_equation)
 end
 


### PR DESCRIPTION
in `main` we have centered advection in the vertical. This is mostly just for performance. I think we should use the WENO advection scheme also in the vertical as a default, it is a safer and probably more accurate default. 
People that want to experiment with a more performant simulation can manually change the vertical advection.