### PR TITLE
Bypass certificate verification in downloader

### DIFF
--- a/src/DataWrangling/DataWrangling.jl
+++ b/src/DataWrangling/DataWrangling.jl
@@ -84,8 +84,11 @@ end
 function netrc_downloader(username, password, machine, dir)
     netrc_file = netrc_permission_file(username, password, machine, dir)
     downloader = Downloads.Downloader()
-    easy_hook  = (easy, _) -> Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_NETRC_FILE, netrc_file)
-
+    easy_hook  = (easy, _) -> begin
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_NETRC_FILE, netrc_file)
+        # Bypass certificate verification because ecco.jpl.nasa.gov is using an untrusted CA certificate
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYPEER, false)
+    end
     downloader.easy_hook = easy_hook
     return downloader
 end


### PR DESCRIPTION
The ECCO server is sending an [SSL certificate chain](https://www.ssllabs.com/ssltest/analyze.html?d=ecco.jpl.nasa.gov) that includes Entrust intermediate certificates. Since Entrust root certificates have been distrusted by many platforms, this causes certificate validation failures.

This PR works around the issue by bypassing certificate verification in the `netrc_downloader`. While the data transfer is still encrypted disabling certificate verification means we no longer confirm the server’s authenticity, which does introduce some security risks.