### PR TITLE
Increase timestep for the one-degree global simulation

### DIFF
--- a/examples/one_degree_simulation.jl
+++ b/examples/one_degree_simulation.jl
@@ -92,7 +92,7 @@ set!(seaice.model, h=ecco_sea_ice_thickness, ℵ=ecco_sea_ice_concentration)
 
 # ### Atmospheric forcing
 
-# We force the simulation with the JRA55-do atmospheric reanalysis.
+# We force the simulation with a JRA55-do atmospheric reanalysis.
 radiation  = Radiation(arch)
 atmosphere = JRA55PrescribedAtmosphere(arch; backend=JRA55NetCDFBackend(80))
 


### PR DESCRIPTION
I managed to get a stable simulation for 2 years with 8minute initialization timestep for 20days and then switching to 30minutes.

https://github.com/user-attachments/assets/13dd3162-98e6-41b3-acda-a0b8e776029d

(We should wait for #583 first.)