### PR TITLE
Expose `include_rivers_and_icebergs` kwarg instead of using the default

### DIFF
--- a/examples/near_global_ocean_simulation.jl
+++ b/examples/near_global_ocean_simulation.jl
@@ -105,7 +105,8 @@ radiation = Radiation(arch)
 # The number of snapshots that are loaded into memory is determined by
 # the `backend`. Here, we load 41 snapshots at a time into memory.
 
-atmosphere = JRA55PrescribedAtmosphere(arch; backend=JRA55NetCDFBackend(41))
+atmosphere = JRA55PrescribedAtmosphere(arch; backend = JRA55NetCDFBackend(41),
+                                       include_rivers_and_icebergs = false)
 
 # ## The coupled simulation
 

--- a/examples/one_degree_simulation.jl
+++ b/examples/one_degree_simulation.jl
@@ -95,7 +95,8 @@ set!(seaice.model, h=ecco_sea_ice_thickness, ℵ=ecco_sea_ice_concentration)
 
 # We force the simulation with a JRA55-do atmospheric reanalysis.
 radiation  = Radiation(arch)
-atmosphere = JRA55PrescribedAtmosphere(arch; backend=JRA55NetCDFBackend(80))
+atmosphere = JRA55PrescribedAtmosphere(arch; backend=JRA55NetCDFBackend(80),
+                                       include_rivers_and_icebergs = false)
 
 # ### Coupled simulation
 


### PR DESCRIPTION
Despite `include_rivers_and_icebergs = false` is the default, I think it's good idea to expose it so that it's obvious to anybody that they need to tweak this to include runoff and icebergs.

We might want to consider making `include_rivers_and_icebergs = true` the default at some point.