### PR TITLE
Bump patch release v0.8.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ClimaOcean"
 uuid = "0376089a-ecfe-4b0e-a64f-9c555d74d754"
 license = "MIT"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ SeawaterPolynomials = "0.3.5"
 StaticArrays = "1"
 Statistics = "1.9"
 SurfaceFluxes = "0.11, 0.12"
-Thermodynamics = "0.12, 0.13, 0.14"
+Thermodynamics = "0.14"
 ZipFile = "0.10"
 julia = "1.10"
 

--- a/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/similarity_theory_turbulent_fluxes.jl
@@ -14,7 +14,7 @@ using KernelAbstractions.Extras.LoopInfo: @unroll
 using Statistics: norm
 
 import Thermodynamics as AtmosphericThermodynamics
-import Thermodynamics.Parameters: molmass_ratio
+import Thermodynamics.Parameters: Rv_over_Rd
 
 #####
 ##### Bulk turbulent fluxes based on similarity theory
@@ -259,7 +259,7 @@ L_★ = u_★² / ϰ b_★ .
 @inline function buoyancy_scale(θ★, q★, ℂ, 𝒬, g)
     𝒯ₐ = AtmosphericThermodynamics.virtual_temperature(ℂ, 𝒬)
     qₐ = AtmosphericThermodynamics.vapor_specific_humidity(ℂ, 𝒬)
-    ε  = AtmosphericThermodynamics.Parameters.molmass_ratio(ℂ)
+    ε  = AtmosphericThermodynamics.Parameters.Rv_over_Rd(ℂ)
     δ  = ε - 1 # typically equal to 0.608
 
     b★ = g / 𝒯ₐ * (θ★ * (1 + δ * qₐ) + δ * 𝒯ₐ * q★)

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -16,7 +16,7 @@ import Thermodynamics.Parameters:
     gas_constant,   #
     molmass_dryair, # Molar mass of dry air (without moisture)
     molmass_water,  # Molar mass of gaseous water vapor
-    molmass_ratio,  # Ratio of the molar masses of dry air to water vapor
+    Rv_over_Rd,     # Ratio of the molar masses of dry air to water vapor
     R_v,            # Specific gas constant for water vapor
     R_d,            # Specific gas constant for dry air
     kappa_d,        # Ideal gas adiabatic exponent for dry air
@@ -102,7 +102,7 @@ const CP{FT} = ConstitutiveParameters{FT} where FT
 @inline gas_constant(p::CP)   = p.gas_constant
 @inline molmass_dryair(p::CP) = p.dry_air_molar_mass
 @inline molmass_water(p::CP)  = p.water_molar_mass
-@inline molmass_ratio(p::CP)  = molmass_dryair(p) / molmass_water(p)
+@inline Rv_over_Rd(p::CP)     = molmass_dryair(p) / molmass_water(p)
 @inline R_v(p::CP)            = gas_constant(p) / molmass_water(p)
 @inline R_d(p::CP)            = gas_constant(p) / molmass_dryair(p)
 
@@ -261,7 +261,7 @@ const ATP = AtmosphereThermodynamicsParameters
 @inline gas_constant(p::ATP)   = gas_constant(p.constitutive)
 @inline molmass_dryair(p::ATP) = molmass_dryair(p.constitutive)
 @inline molmass_water(p::ATP)  = molmass_water(p.constitutive)
-@inline molmass_ratio(p::ATP)  = molmass_ratio(p.constitutive)
+@inline Rv_over_Rd(p::ATP)     = Rv_over_Rd(p.constitutive)
 @inline LH_v0(p::ATP)          = LH_v0(p.phase_transitions)
 @inline LH_s0(p::ATP)          = LH_s0(p.phase_transitions)
 @inline LH_f0(p::ATP)          = LH_f0(p.phase_transitions)

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -16,7 +16,7 @@ import Thermodynamics.Parameters:
     gas_constant,   #
     molmass_dryair, # Molar mass of dry air (without moisture)
     molmass_water,  # Molar mass of gaseous water vapor
-    Rv_over_Rd,     # Ratio of the molar masses of dry air to water vapor
+    Rv_over_Rd,     # Ratio of the specific gas constants of water vapor over dry air
     R_v,            # Specific gas constant for water vapor
     R_d,            # Specific gas constant for dry air
     kappa_d,        # Ideal gas adiabatic exponent for dry air

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -13,32 +13,32 @@ using Thermodynamics.Parameters: AbstractThermodynamicsParameters
 import Oceananigans.TimeSteppers: time_step!, update_state!
 
 import Thermodynamics.Parameters:
-    universal_gas_constant,   #
-    molmass_dryair,           # Molar mass of dry air (without moisture)
-    molmass_water,            # Molar mass of gaseous water vapor
-    Rv_over_Rd,               # Ratio of the specific gas constants of water vapor over dry air
-    R_v,                      # Specific gas constant for water vapor
-    R_d,                      # Specific gas constant for dry air
-    kappa_d,                  # Ideal gas adiabatic exponent for dry air
-    T_0,                      # Enthalpy reference temperature
-    LH_v0,                    # Vaporization enthalpy at the reference temperature
-    LH_s0,                    # Sublimation enthalpy at the reference temperature
-    LH_f0,                    # Fusion enthalpy at the reference temperature
-    cp_d,                     # Heat capacity of dry air at constant pressure
-    cp_v,                     # Isobaric specific heat capacity of gaseous water vapor
-    cp_l,                     # Isobaric specific heat capacity of liquid water
-    cp_i,                     # Isobaric specific heat capacity of water ice
-    cv_v,                     # Heat capacity of dry air at constant volume
-    cv_l,                     # Isobaric specific heat capacity of liquid water
-    cv_i,                     # Isobaric specific heat capacity of liquid water
-    e_int_v0,                 # what? something about reference internal energy of water vapor
-    T_freeze,                 # Freezing temperature of _pure_ water
-    T_triple,                 # Triple point temperature of _pure_ water
-    press_triple,             # Triple point pressure of pure water
-    T_icenuc,                 # Lower temperature limit for the presence of liquid condensate
-                              # (below which homogeneous ice nucleation occurs)
-    pow_icenuc                # "Power parameter" that controls liquid/ice condensate partitioning
-                              # during partial ice nucleation
+    gas_constant,   #
+    molmass_dryair, # Molar mass of dry air (without moisture)
+    molmass_water,  # Molar mass of gaseous water vapor
+    Rv_over_Rd,     # Ratio of the specific gas constants of water vapor over dry air
+    R_v,            # Specific gas constant for water vapor
+    R_d,            # Specific gas constant for dry air
+    kappa_d,        # Ideal gas adiabatic exponent for dry air
+    T_0,            # Enthalpy reference temperature
+    LH_v0,          # Vaporization enthalpy at the reference temperature
+    LH_s0,          # Sublimation enthalpy at the reference temperature
+    LH_f0,          # Fusion enthalpy at the reference temperature
+    cp_d,           # Heat capacity of dry air at constant pressure
+    cp_v,           # Isobaric specific heat capacity of gaseous water vapor
+    cp_l,           # Isobaric specific heat capacity of liquid water
+    cp_i,           # Isobaric specific heat capacity of water ice
+    cv_v,           # Heat capacity of dry air at constant volume
+    cv_l,           # Isobaric specific heat capacity of liquid water
+    cv_i,           # Isobaric specific heat capacity of liquid water
+    e_int_v0,       # what? something about reference internal energy of water vapor
+    T_freeze,       # Freezing temperature of _pure_ water
+    T_triple,       # Triple point temperature of _pure_ water
+    press_triple,   # Triple point pressure of pure water
+    T_icenuc,       # Lower temperature limit for the presence of liquid condensate
+                    # (below which homogeneous ice nucleation occurs)
+    pow_icenuc      # "Power parameter" that controls liquid/ice condensate partitioning
+                    # during partial ice nucleation
 
 import ..OceanSeaIceModels:
     downwelling_radiation,

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -103,7 +103,7 @@ const CP{FT} = ConstitutiveParameters{FT} where FT
 @inline molmass_dryair(p::CP) = p.dry_air_molar_mass
 @inline molmass_water(p::CP)  = p.water_molar_mass
 @inline Rv_over_Rd(p::CP)     = molmass_dryair(p) / molmass_water(p)
-@inline R_v(p::CP)            = gas_constant(p) / molmass_water(p
+@inline R_v(p::CP)            = gas_constant(p) / molmass_water(p)
 @inline R_d(p::CP)            = gas_constant(p) / molmass_dryair(p)
 
 struct HeatCapacityParameters{FT} <: AbstractThermodynamicsParameters{FT}

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -102,7 +102,7 @@ const CP{FT} = ConstitutiveParameters{FT} where FT
 @inline gas_constant(p::CP)   = p.gas_constant
 @inline molmass_dryair(p::CP) = p.dry_air_molar_mass
 @inline molmass_water(p::CP)  = p.water_molar_mass
-@inline Rv_over_Rd(p::CP)     = p.Rv_over_Rd
+@inline Rv_over_Rd(p::CP)     = molmass_dryair(p) / molmass_water(p)
 @inline R_v(p::CP)            = gas_constant(p) / molmass_water(p
 @inline R_d(p::CP)            = gas_constant(p) / molmass_dryair(p)
 

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -64,7 +64,7 @@ end
 Base.show(io::IO, p::ConstitutiveParameters) = print(io, summary(p))
 
 """
-    ConstitutiveParameters(FT = Float64;
+    ConstitutiveParameters(FT = Oceananigans.defaults.FloatType;
                            gas_constant       = 8.3144598,
                            dry_air_molar_mass = 0.02897,
                            water_molar_mass   = 0.018015)
@@ -124,7 +124,7 @@ end
 Base.show(io::IO, p::HeatCapacityParameters) = print(io, summary(p))
 
 """
-    HeatCapacityParameters(FT = Float64,
+    HeatCapacityParameters(FT = Oceananigans.defaults.FloatType;
                            dry_air_adiabatic_exponent = 2/7,
                            water_vapor_heat_capacity = 1859,
                            liquid_water_heat_capacity = 4181,
@@ -247,9 +247,9 @@ function Base.show(io::IO, p::AtmosphereThermodynamicsParameters)
 end
 
 function AtmosphereThermodynamicsParameters(FT = Oceananigans.defaults.FloatType;
-                                                      constitutive = ConstitutiveParameters(FT),
-                                                      phase_transitions = PhaseTransitionParameters(FT),
-                                                      heat_capacity = HeatCapacityParameters(FT))
+                                            constitutive = ConstitutiveParameters(FT),
+                                            phase_transitions = PhaseTransitionParameters(FT),
+                                            heat_capacity = HeatCapacityParameters(FT))
 
     return AtmosphereThermodynamicsParameters(constitutive, heat_capacity, phase_transitions)
 end
@@ -377,11 +377,11 @@ end
 @inline boundary_layer_height(atmos::PrescribedAtmosphere) = atmos.boundary_layer_height
 
 """
-    PrescribedAtmosphere(grid, times;
+    PrescribedAtmosphere(grid, times=[zero(grid)];
                          clock = Clock{Float64}(time = 0),
                          surface_layer_height = 10, # meters
                          boundary_layer_height = 512 # meters,
-                         thermodynamics_parameters = AtmosphereThermodynamicsParameters(FT),
+                         thermodynamics_parameters = nothing,
                          auxiliary_freshwater_flux = nothing,
                          velocities            = default_atmosphere_velocities(grid, times),
                          tracers               = default_atmosphere_tracers(grid, times),

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -1,11 +1,11 @@
 module PrescribedAtmospheres
 
 using Oceananigans
-using Oceananigans.Grids: grid_name
-using Oceananigans.Utils: prettysummary, Time
 using Oceananigans.Fields: Center
+using Oceananigans.Grids: grid_name
 using Oceananigans.OutputReaders: FieldTimeSeries, update_field_time_series!, extract_field_time_series
 using Oceananigans.TimeSteppers: Clock, tick!
+using Oceananigans.Utils: prettysummary, Time
 
 using Adapt
 using Thermodynamics.Parameters: AbstractThermodynamicsParameters
@@ -13,32 +13,32 @@ using Thermodynamics.Parameters: AbstractThermodynamicsParameters
 import Oceananigans.TimeSteppers: time_step!, update_state!
 
 import Thermodynamics.Parameters:
-    gas_constant,   #
-    molmass_dryair, # Molar mass of dry air (without moisture)
-    molmass_water,  # Molar mass of gaseous water vapor
-    Rv_over_Rd,     # Ratio of the specific gas constants of water vapor over dry air
-    R_v,            # Specific gas constant for water vapor
-    R_d,            # Specific gas constant for dry air
-    kappa_d,        # Ideal gas adiabatic exponent for dry air
-    T_0,            # Enthalpy reference temperature
-    LH_v0,          # Vaporization enthalpy at the reference temperature
-    LH_s0,          # Sublimation enthalpy at the reference temperature
-    LH_f0,          # Fusionn enthalpy at the reference temperature
-    cp_d,           # Heat capacity of dry air at constant pressure
-    cp_v,           # Isobaric specific heat capacity of gaseous water vapor
-    cp_l,           # Isobaric specific heat capacity of liquid water
-    cp_i,           # Isobaric specific heat capacity of water ice
-    cv_v,           # Heat capacity of dry air at constant volume
-    cv_l,           # Isobaric specific heat capacity of liquid water
-    cv_i,           # Isobaric specific heat capacity of liquid water
-    e_int_v0,       # what? someting about reference internal energy of water vapor
-    T_freeze,       # Freezing temperature of _pure_ water
-    T_triple,       # Triple point temperature of _pure_ water
-    press_triple,   # Triple point pressure of pure water
-    T_icenuc,       # Lower temperature limit for the presence of liquid condensate
-                    # (below which homogeneous ice nucleation occurs)
-    pow_icenuc      # "Power parameter" that controls liquid/ice condensate partitioning
-                    # during partial ice nucleation
+    universal_gas_constant,   #
+    molmass_dryair,           # Molar mass of dry air (without moisture)
+    molmass_water,            # Molar mass of gaseous water vapor
+    Rv_over_Rd,               # Ratio of the specific gas constants of water vapor over dry air
+    R_v,                      # Specific gas constant for water vapor
+    R_d,                      # Specific gas constant for dry air
+    kappa_d,                  # Ideal gas adiabatic exponent for dry air
+    T_0,                      # Enthalpy reference temperature
+    LH_v0,                    # Vaporization enthalpy at the reference temperature
+    LH_s0,                    # Sublimation enthalpy at the reference temperature
+    LH_f0,                    # Fusion enthalpy at the reference temperature
+    cp_d,                     # Heat capacity of dry air at constant pressure
+    cp_v,                     # Isobaric specific heat capacity of gaseous water vapor
+    cp_l,                     # Isobaric specific heat capacity of liquid water
+    cp_i,                     # Isobaric specific heat capacity of water ice
+    cv_v,                     # Heat capacity of dry air at constant volume
+    cv_l,                     # Isobaric specific heat capacity of liquid water
+    cv_i,                     # Isobaric specific heat capacity of liquid water
+    e_int_v0,                 # what? something about reference internal energy of water vapor
+    T_freeze,                 # Freezing temperature of _pure_ water
+    T_triple,                 # Triple point temperature of _pure_ water
+    press_triple,             # Triple point pressure of pure water
+    T_icenuc,                 # Lower temperature limit for the presence of liquid condensate
+                              # (below which homogeneous ice nucleation occurs)
+    pow_icenuc                # "Power parameter" that controls liquid/ice condensate partitioning
+                              # during partial ice nucleation
 
 import ..OceanSeaIceModels:
     downwelling_radiation,
@@ -102,9 +102,9 @@ const CP{FT} = ConstitutiveParameters{FT} where FT
 @inline gas_constant(p::CP)   = p.gas_constant
 @inline molmass_dryair(p::CP) = p.dry_air_molar_mass
 @inline molmass_water(p::CP)  = p.water_molar_mass
-@inline Rv_over_Rd(p::CP)     = molmass_dryair(p) / molmass_water(p)
-@inline R_v(p::CP)            = gas_constant(p) / molmass_water(p)
-@inline R_d(p::CP)            = gas_constant(p) / molmass_dryair(p)
+@inline Rv_over_Rd(p::CP)     = p.Rv_over_Rd
+@inline R_v(p::CP)            = p.R_v
+@inline R_d(p::CP)            = p.R_d
 
 struct HeatCapacityParameters{FT} <: AbstractThermodynamicsParameters{FT}
     dry_air_adiabatic_exponent :: FT

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -103,8 +103,8 @@ const CP{FT} = ConstitutiveParameters{FT} where FT
 @inline molmass_dryair(p::CP) = p.dry_air_molar_mass
 @inline molmass_water(p::CP)  = p.water_molar_mass
 @inline Rv_over_Rd(p::CP)     = p.Rv_over_Rd
-@inline R_v(p::CP)            = p.R_v
-@inline R_d(p::CP)            = p.R_d
+@inline R_v(p::CP)            = gas_constant(p) / molmass_water(p
+@inline R_d(p::CP)            = gas_constant(p) / molmass_dryair(p)
 
 struct HeatCapacityParameters{FT} <: AbstractThermodynamicsParameters{FT}
     dry_air_adiabatic_exponent :: FT

--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -76,7 +76,7 @@ Construct a set of parameters that define the density of moist air,
 ```
 
 where ``p`` is pressure, ``T`` is temperature, ``q`` defines the partition
-of total mass into vapor, liqiud, and ice mass fractions, and
+of total mass into vapor, liquid, and ice mass fractions, and
 ``Rᵐ`` is the effective specific gas constant for the mixture,
 
 ```math
@@ -213,9 +213,9 @@ end
 const ATP{FT} = AtmosphereThermodynamicsParameters{FT} where FT
 
 Base.eltype(::ATP{FT}) where FT = FT
-Base.eltype(::CP{FT})   where FT = FT
-Base.eltype(::HCP{FT})  where FT = FT
-Base.eltype(::PTP{FT})  where FT = FT
+Base.eltype(::CP{FT})  where FT = FT
+Base.eltype(::HCP{FT}) where FT = FT
+Base.eltype(::PTP{FT}) where FT = FT
 
 Base.summary(::ATP{FT}) where FT = "AtmosphereThermodynamicsParameters{$FT}"
 
@@ -344,8 +344,8 @@ function default_freshwater_flux(grid, times)
     return (; rain, snow)
 end
 
-""" The standard unit of atmospheric pressure; 1 standard atmosphere (atm) = 101,325 Pascals (Pa) in SI units.
-This is approximately equal to the mean sea-level atmospheric pressure on Earth. """
+""" The standard unit of atmospheric pressure; 1 standard atmosphere (atm) = 101,325 Pascals (Pa)
+in SI units. This is approximately equal to the mean sea-level atmospheric pressure on Earth. """
 function default_atmosphere_pressure(grid, times)
     pa = FieldTimeSeries{Center, Center, Nothing}(grid, times)
     parent(pa) .= 101325


### PR DESCRIPTION
Tag a patch release so ClimaCoupler can use Thermodynamics v0.14 downstream (compat added in https://github.com/CliMA/ClimaOcean.jl/pull/603)