### PR TITLE
Update PrescribedAtmosphere `default thermodynamics_parameters`

### DIFF
--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -381,7 +381,7 @@ end
                          clock = Clock{Float64}(time = 0),
                          surface_layer_height = 10, # meters
                          boundary_layer_height = 512 # meters,
-                         thermodynamics_parameters = AtmosphereThermodynamicsParameters(FT),
+                         thermodynamics_parameters = AtmosphereThermodynamicsParameters(eltype(grid)),
                          auxiliary_freshwater_flux = nothing,
                          velocities            = default_atmosphere_velocities(grid, times),
                          tracers               = default_atmosphere_tracers(grid, times),
@@ -396,7 +396,7 @@ function PrescribedAtmosphere(grid, times=[zero(grid)];
                               clock = Clock{Float64}(time = 0),
                               surface_layer_height = 10,
                               boundary_layer_height = 512,
-                              thermodynamics_parameters = AtmosphereThermodynamicsParameters(FT),
+                              thermodynamics_parameters = AtmosphereThermodynamicsParameters(eltype(grid)),
                               auxiliary_freshwater_flux = nothing,
                               velocities            = default_atmosphere_velocities(grid, times),
                               tracers               = default_atmosphere_tracers(grid, times),


### PR DESCRIPTION
Fix a bug introduced in #606; default doesn't know what `FT` is.

Without this bug fix, on v0.8.3 this fails:

```Julia
julia> atmosphere = JRA55PrescribedAtmosphere(arch; backend=JRA55NetCDFBackend(80),
                                              include_rivers_and_icebergs = false)
ERROR: UndefVarError: `FT` not defined
Stacktrace:
 [1] JRA55PrescribedAtmosphere(architecture::GPU{…}, FT::Type; dataset::RepeatYearJRA55, start_date::DateTime, end_date::DateTime, backend::JRA55NetCDFBackend{…}, time_indexing::Oceananigans.OutputReaders.Cyclical{…}, surface_layer_height::Int64, include_rivers_and_icebergs::Bool, other_kw::@Kwargs{})
   @ ClimaOcean.DataWrangling.JRA55 ~/ClimaOcean.jl/src/DataWrangling/JRA55/JRA55_prescribed_atmosphere.jl:75
 [2] JRA55PrescribedAtmosphere
   @ ~/ClimaOcean.jl/src/DataWrangling/JRA55/JRA55_prescribed_atmosphere.jl:22 [inlined]
 [3] top-level scope
   @ REPL[25]:1
Some type information was truncated. Use `show(err)` to see complete types.
```