### PR TITLE
Add general conservative regridder for tracers

### DIFF
--- a/src/Diagnostics/Diagnostics.jl
+++ b/src/Diagnostics/Diagnostics.jl
@@ -1,6 +1,8 @@
 module Diagnostics
 
 export MixedLayerDepthField, MixedLayerDepthOperand
+export regrid_tracers!, regridder_weights
+
 
 using Oceananigans
 using Oceananigans.Architectures: architecture
@@ -15,5 +17,8 @@ import Oceananigans.Fields: compute!
 using KernelAbstractions: @index, @kernel
 
 include("mixed_layer_depth.jl")
+include("regridder.jl")
 
-end # module
+using .Regridder
+
+end # module Diagnostics

--- a/src/Diagnostics/regridder.jl
+++ b/src/Diagnostics/regridder.jl
@@ -1,2 +1,190 @@
+module Regridder
 ### This is where the xESMF regridder goes
+    using Oceananigans
+    using Oceananigans.Fields: location, ReducedField
+    using Oceananigans.Grids: AbstractGrid
 
+
+    using PyCall
+    using SparseArrays
+    using LinearAlgebra
+
+    export regrid_tracers!, regridder_weights
+
+    """
+        regridder_weights!(source_field, destination_field; method = "conservative")
+    
+    Regrid the `source_field` onto the `destination_field` using the specified method.
+    xESMF exposes five different regridding algorithms from the ESMF library, specified with the `method` keyword argument:
+
+    bilinear: ESMF.RegridMethod.BILINEAR
+    conservative: ESMF.RegridMethod.CONSERVE
+    conservative_normed: ESMF.RegridMethod.CONSERVE
+    patch: ESMF.RegridMethod.PATCH
+    nearest_s2d: ESMF.RegridMethod.NEAREST_STOD
+    nearest_d2s: ESMF.RegridMethod.NEAREST_DTOS
+
+    where conservative_normed is just the conservative method with the normalization set to ESMF.NormType.FRACAREA instead of the default norm_type=ESMF.NormType.DSTAREA.
+    For more information, see the xESMF documentation: https://xesmf.readthedocs.io/en/latest/notebooks/Compare_algorithms.html
+    """
+
+    const SomeTripolarGrid = Union{TripolarGrid, ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:TripolarGrid}}
+    const SomeLatitudeLongitudeGrid = Union{LatitudeLongitudeGrid, ImmersedBoundaryGrid{<:Any, <:Any, <:Any, <:Any, <:LatitudeLongitudeGrid}}
+    const TripolarOrLatLonGrid = Union{SomeTripolarGrid, SomeLatitudeLongitudeGrid}
+
+    # Import and store as constants for submodules
+    function get_np()
+        return pyimport("numpy")
+    end
+
+    function get_xesmf()
+        return pyimport("xesmf")
+    end
+
+    function get_xr()
+        return pyimport("xarray")
+    end
+
+
+    function two_dimensionalize(lat::AbstractVector, lon::AbstractVector) 
+        Nx = length(lon)
+        Ny = length(lat)
+        lat = repeat(lat', Nx)
+        lon = repeat(lon, 1, Ny)
+
+        return lat, lon
+    end
+
+    function coordinate_dataset(grid::SomeLatitudeLongitudeGrid)
+        lat = Array(φnodes(grid, Center(), Center(), Center()))
+        lon = Array(λnodes(grid, Center(), Center(), Center()))
+
+        lat_b = Array(φnodes(grid, Face(), Face(), Center()))
+        lon_b = Array(grid.λᶠᵃᵃ[1:grid.Nx+1])
+
+        lat,   lon   = two_dimensionalize(lat,   lon)
+        lat_b, lon_b = two_dimensionalize(lat_b, lon_b)
+
+        return structured_coordinate_dataset(lat, lon, lat_b, lon_b)
+    end
+
+    function coordinate_dataset(grid::SomeTripolarGrid)
+        lat = Array(grid.φᶜᶜᵃ[1:grid.Nx, 1:grid.Ny])
+        lon = Array(grid.λᶜᶜᵃ[1:grid.Nx, 1:grid.Ny])
+
+        lat_b = Array(grid.φᶠᶠᵃ[1:grid.Nx+1, 1:grid.Ny+1])
+        lon_b = Array(grid.λᶠᶠᵃ[1:grid.Nx+1, 1:grid.Ny+1])
+
+        return structured_coordinate_dataset(lat, lon, lat_b, lon_b)
+    end
+
+    function structured_coordinate_dataset(lat, lon, lat_b, lon_b)
+        numpy  = get_np()
+        xarray = get_xr()
+
+        lat = numpy.array(lat)
+        lon = numpy.array(lon)
+
+        lat_b = numpy.array(lat_b)
+        lon_b = numpy.array(lon_b)
+
+        ds_lat = xarray.DataArray(
+            lat',
+            dims=["y", "x"],
+            coords= PyObject(Dict(
+                "lat" => (["y", "x"], lat'),
+                "lon" => (["y", "x"], lon')
+            )),
+            name="latitude"
+        )
+
+        ds_lon = xarray.DataArray(
+            lon',
+            dims=["y", "x"],
+            coords= PyObject(Dict(
+                "lat" => (["y", "x"], lat'),
+                "lon" => (["y", "x"], lon')
+            )),
+            name="longitude"
+        )
+
+        ds_lat_b = xarray.DataArray(
+            lat_b',
+            dims=["y_b", "x_b"],
+            coords= PyObject(Dict(
+                "lat_b" => (["y_b", "x_b"], lat_b'),
+                "lon_b" => (["y_b", "x_b"], lon_b')
+            )),
+        )
+
+        ds_lon_b = xarray.DataArray(
+            lon_b',
+            dims=["y_b", "x_b"],
+            coords= PyObject(Dict(
+                "lat_b" => (["y_b", "x_b"], lat_b'),
+                "lon_b" => (["y_b", "x_b"], lon_b')
+            )),
+        )
+
+        return  xarray.Dataset(
+            PyObject(
+                Dict("lat"   => ds_lat, 
+                    "lon"   => ds_lon,
+                    "lat_b" => ds_lat_b,
+                    "lon_b" => ds_lon_b))
+        )
+    end
+
+
+    function regridder_weights(
+    source_field::Field, 
+    destination_field::Field; 
+    method::String = "conservative")
+
+        # Create source and destination fields
+
+        src_ds = coordinate_dataset(source_field.grid)
+        dst_ds = coordinate_dataset(destination_field.grid)
+
+        regridder = get_xesmf().Regridder(src_ds, dst_ds, method, periodic=PyObject(true))
+
+        # Move back to Julia
+        # Convert the regridder weights to a Julia sparse matrix
+        coo = regridder.weights.data
+        coords = coo[:coords]
+        rows = coords[1,:].+1
+        cols = coords[2,:].+1
+        vals = Float64.(coo[:data])
+
+        shape = Tuple(Int.(coo[:shape]))
+        W = sparse(rows, cols, vals, shape[1], shape[2])
+
+        return W
+    end
+
+    """
+        regrid_tracers!(src::Field, dst::Field, W::SparseMatrixCSC)
+    Regrid the `src` field onto the `dst` field using the provided weights `W`.
+    The function assumes that the vertical grid (z) of both fields is the same.
+    """
+    
+    function regrid_tracers!(dst::Field, W::SparseMatrixCSC, src::Field)
+
+        @assert dst.grid.z.cᵃᵃᶜ[1:dst.grid.Nz] == src.grid.z.cᵃᵃᶜ[1:src.grid.Nz] "Source and destination grids must have exactly the same vertical grid (z)."
+        
+        # Perform regridding
+        for k in 1:dst.grid.Nz
+            # Flatten the source field for regridding
+            src_flat = vec(collect(interior(src))[:,:,k])  # shape (ncell, 1)
+
+            # Regrid the source field to the destination grid
+            # LinearAlgebra.mul!(vec(interior(dst, :, :, k)), W, vec(interior(src, :, :, k)))            
+            dst_vec = reshape(W * src_flat, dst.grid.Nx, dst.grid.Ny)
+
+            # # Fill the destination field with the regridded values
+            interior(dst)[:,:,k] .= dst_vec
+        end
+        return nothing
+    end
+
+end # module Regridder


### PR DESCRIPTION
I have created a wrapper for xESMF (python package) so we can generally regrid any field from source to destination. At the moment, the PR doesn't include vertical regrinding (i.e., source and destinations vertical grids need to be the same). 

Also, there are some speed ups that could be achieved in the actual matrix multiplication step. 