### PR TITLE
add colon2dash function to fix prefix

### DIFF
--- a/src/DataWrangling/Copernicus/Copernicus.jl
+++ b/src/DataWrangling/Copernicus/Copernicus.jl
@@ -93,6 +93,8 @@ function bbox_strs(c)
     return first, second
 end
 
+colon2dash(s::String) = replace(s, ":" => "-")
+
 function metadata_prefix(metadata::CopernicusMetadata)
     var = copernicus_dataset_variable_names[metadata.name]
     dataset = dataset_name(metadata.dataset)
@@ -109,7 +111,7 @@ function metadata_prefix(metadata::CopernicusMetadata)
     return string(var, "_",
                   dataset, "_",
                   start_date, "_",
-                  end_date, suffix)
+                  end_date, suffix) |> colon2dash
 end
 
 function metadata_filename(metadata::CopernicusMetadata)


### PR DESCRIPTION
Closes #616.
The simple solution is to apply a `colon2dash` function to preprocess `metadata_prefix` to avoid having colons in filenames