### PR TITLE
Restructure sea ice ocean fluxes

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
@@ -42,7 +42,7 @@ function compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, mel
     # Is it immediately removed from the ocean? Or is it stored in the ice?
     launch!(arch, grid, :xy, _compute_sea_ice_ocean_fluxes!,
             sea_ice_ocean_fluxes, grid, clock, hᵢ, ℵᵢ, Sᵢ, Gh, Tₒ, Sₒ, uᵢ, vᵢ,
-            τs, liquidus, ocean_properties, characteristic_melting_speed, Δt)
+            τs, liquidus, ocean_properties, melting_speed, Δt)
 
     return nothing
 end

--- a/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
@@ -15,7 +15,7 @@ function compute_sea_ice_ocean_fluxes!(coupled_model)
     return nothing
 end
 
-function compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, melting_speed, ocean_properties))
+function compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, melting_speed, ocean_properties)
     Δt = ocean.Δt
     Tₒ = ocean.model.tracers.T
     Sₒ = ocean.model.tracers.S

--- a/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
@@ -3,12 +3,19 @@ using ClimaSeaIce.SeaIceThermodynamics: melting_temperature
 using ClimaSeaIce.SeaIceDynamics: x_momentum_stress, y_momentum_stress
 
 function compute_sea_ice_ocean_fluxes!(coupled_model)
-    ocean = coupled_model.ocean
+    ocean   = coupled_model.ocean
     sea_ice = coupled_model.sea_ice
 
-    sea_ice_ocean_fluxes = coupled_model.interfaces.sea_ice_ocean_interface.fluxes
-    interface_properties = coupled_model.interfaces.sea_ice_ocean_interface.properties
+    sea_ice_ocean_fluxes = coupled_model.interfaces.sea_ice_ocean_interface.fluxes 
+    melting_speed        = coupled_model.interfaces.sea_ice_ocean_interface.properties.melting_speed
+    ocean_properties     = coupled_model.interfaces.ocean_properties
 
+    compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, melting_speed, ocean_properties)
+    
+    return nothing
+end
+
+function compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, melting_speed, ocean_properties))
     Δt = ocean.Δt
     Tₒ = ocean.model.tracers.T
     Sₒ = ocean.model.tracers.S
@@ -17,7 +24,6 @@ function compute_sea_ice_ocean_fluxes!(coupled_model)
     hᵢ = sea_ice.model.ice_thickness
     Gh = sea_ice.model.ice_thermodynamics.thermodynamic_tendency
 
-    ocean_properties = coupled_model.interfaces.ocean_properties
     liquidus = sea_ice.model.ice_thermodynamics.phase_transitions.liquidus
     grid  = ocean.model.grid
     clock = ocean.model.clock
@@ -36,7 +42,7 @@ function compute_sea_ice_ocean_fluxes!(coupled_model)
     # Is it immediately removed from the ocean? Or is it stored in the ice?
     launch!(arch, grid, :xy, _compute_sea_ice_ocean_fluxes!,
             sea_ice_ocean_fluxes, grid, clock, hᵢ, ℵᵢ, Sᵢ, Gh, Tₒ, Sₒ, uᵢ, vᵢ,
-            τs, liquidus, ocean_properties, interface_properties, Δt)
+            τs, liquidus, ocean_properties, characteristic_melting_speed, Δt)
 
     return nothing
 end
@@ -55,7 +61,7 @@ end
                                                 sea_ice_ocean_stresses,
                                                 liquidus,
                                                 ocean_properties,
-                                                interface_properties,
+                                                characteristic_melting_speed,
                                                 Δt)
 
     i, j = @index(Global, NTuple)
@@ -75,7 +81,7 @@ end
     ℵᵢ  = ice_concentration
     ρₒ  = ocean_properties.reference_density
     cₒ  = ocean_properties.heat_capacity
-    uₘ★ = interface_properties.characteristic_melting_speed
+    uₘ★ = characteristic_melting_speed
 
     δQ_frazil = zero(grid)
 

--- a/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/sea_ice_ocean_fluxes.jl
@@ -7,8 +7,8 @@ function compute_sea_ice_ocean_fluxes!(coupled_model)
     sea_ice = coupled_model.sea_ice
 
     sea_ice_ocean_fluxes = coupled_model.interfaces.sea_ice_ocean_interface.fluxes 
-    melting_speed        = coupled_model.interfaces.sea_ice_ocean_interface.properties.melting_speed
-    ocean_properties     = coupled_model.interfaces.ocean_properties
+    melting_speed    = coupled_model.interfaces.sea_ice_ocean_interface.properties.characteristic_melting_speed
+    ocean_properties = coupled_model.interfaces.ocean_properties
 
     compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, melting_speed, ocean_properties)
     


### PR DESCRIPTION
With @juliasloan25, we are restructuring the ocean-sea ice fluxes computation so that we can reuse the ClimaOcean function without necessarily needing to build out an `OceanSeaIceModel` from climaocean for use in `ClimaCoupler`. 
In this way, we can call 

```julia
compute_sea_ice_ocean_fluxes!(sea_ice_ocean_fluxes, ocean, sea_ice, melting_speed, ocean_properties)
```

from ClimaCoupler by passing the correct input, and the coupled simulation will compute the ocean-seaice interfacial fluxes.