### PR TITLE
Allow passing a `COPERNICUS_USERNAME` and `COPERNICUS_PASSWORD ` as enviroment variables

### DIFF
--- a/ext/ClimaOceanPythonCallExt.jl
+++ b/ext/ClimaOceanPythonCallExt.jl
@@ -77,7 +77,7 @@ function download_dataset(meta::CopernicusMetadatum;
           output_directory)
 
     if !isnothing(username) && !isnothing(password)
-        kw = merge(kw, (; copernicus_username=username, copernicus_password=password))
+        kw = merge(kw, (; username, password))
     end
 
     additional_kw = NamedTuple(name => value for (name, value) in additional_kw)

--- a/ext/ClimaOceanPythonCallExt.jl
+++ b/ext/ClimaOceanPythonCallExt.jl
@@ -35,7 +35,12 @@ function download_dataset(metadata::CopernicusMetadata; kwargs...)
     return paths
 end
 
-function download_dataset(meta::CopernicusMetadatum; skip_existing = true, additional_kw...)
+function download_dataset(meta::CopernicusMetadatum; 
+                          skip_existing=true, 
+                          username=get(ENV, "copernicus_username", nothing),
+                          password=get(ENV, "copernicus_password", nothing),
+                          additional_kw...)
+
     output_directory = meta.dir
     output_filename = ClimaOcean.DataWrangling.metadata_filename(meta)
     output_path = joinpath(output_directory, output_filename)
@@ -70,6 +75,10 @@ function download_dataset(meta::CopernicusMetadatum; skip_existing = true, addit
           variables,
           output_filename,
           output_directory)
+
+    if !isnothing(username) && !isnothing(password)
+        kw = merge(kw, (; copernicus_username=username, copernicus_password=password))
+    end
 
     additional_kw = NamedTuple(name => value for (name, value) in additional_kw)
     kw = merge(kw, datetime_kw, lon_kw, lat_kw, z_kw, additional_kw)

--- a/ext/ClimaOceanPythonCallExt.jl
+++ b/ext/ClimaOceanPythonCallExt.jl
@@ -80,9 +80,8 @@ function download_dataset(meta::CopernicusMetadatum;
         kw = merge(kw, (; username, password))
     else
         @warn "No Copernicus credentials found. \\ 
-        Set the COPERNICUS_USERNAME and COPERNICUS_PASSWORD environment variables to download data \\
-        from the Copernicus Marine Service. \\
-        You can sign up for free at: https://data.marine.copernicus.eu/register"
+        Set the COPERNICUS_USERNAME and COPERNICUS_PASSWORD environment variables to download data from the Copernicus Marine Service. \\
+        You can sign up for free at: https://data.marine.copernicus.eu/register."
     end
 
     additional_kw = NamedTuple(name => value for (name, value) in additional_kw)

--- a/ext/ClimaOceanPythonCallExt.jl
+++ b/ext/ClimaOceanPythonCallExt.jl
@@ -37,8 +37,8 @@ end
 
 function download_dataset(meta::CopernicusMetadatum; 
                           skip_existing=true, 
-                          username=get(ENV, "copernicus_username", nothing),
-                          password=get(ENV, "copernicus_password", nothing),
+                          username=get(ENV, "COPERNICUS_USERNAME", nothing),
+                          password=get(ENV, "COPERNICUS_PASSWORD", nothing),
                           additional_kw...)
 
     output_directory = meta.dir
@@ -78,6 +78,11 @@ function download_dataset(meta::CopernicusMetadatum;
 
     if !isnothing(username) && !isnothing(password)
         kw = merge(kw, (; username, password))
+    else
+        @warn "No Copernicus credentials found. \\ 
+        Set the COPERNICUS_USERNAME and COPERNICUS_PASSWORD environment variables to download data \\
+        from the Copernicus Marine Service. \\
+        You can sign up for free at: https://data.marine.copernicus.eu/register"
     end
 
     additional_kw = NamedTuple(name => value for (name, value) in additional_kw)


### PR DESCRIPTION
at the moment, when we try to download a copernicus dataset, it requires username and password for each date:
```julia
julia> ClimaOcean.DataWrangling.download_dataset(u_meta)
INFO - 2025-10-06T08:21:03Z - Downloading Copernicus Marine data requires a Copernicus Marine username and password, sign up for free at: https://data.marine.copernicus.eu/register
Copernicus Marine username: MyUsername
Copernicus Marine password:
INFO - 2025-10-06T08:21:18Z - Selected dataset version: "202311"
INFO - 2025-10-06T08:21:18Z - Selected dataset part: "default"
INFO - 2025-10-06T08:21:21Z - Starting download. Please wait...
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 23/23 [00:05<00:00,  4.49it/s]
INFO - 2025-10-06T08:21:31Z - Successfully downloaded to /Users/simonesilvestri/.julia/scratchspaces/0376089a-ecfe-4b0e-a64f-9c555d74d754/Copernicus/uo_GLORYSDaily_1993-01-01T00-00-00_1993-01-01T00-00-00_10.2_18.1_41.5_47.8.nc
INFO - 2025-10-06T08:21:31Z - Downloading Copernicus Marine data requires a Copernicus Marine username and password, sign up for free at: https://data.marine.copernicus.eu/register
Copernicus Marine username: MyUsername
Copernicus Marine password:
INFO - 2025-10-06T08:22:05Z - Selected dataset version: "202311"
INFO - 2025-10-06T08:22:05Z - Selected dataset part: "default"
INFO - 2025-10-06T08:22:06Z - Starting download. Please wait...
```
This PR allows passing a `COPERNICUS_USERNAME` and `COPERNICUS_PASSWORD` as environment variables so that we don't have to fill in the details at each download