### PR TITLE
update `PrescribedAtmosphere` state to load correct time indices into memory

### DIFF
--- a/src/OceanSeaIceModels/PrescribedAtmospheres.jl
+++ b/src/OceanSeaIceModels/PrescribedAtmospheres.jl
@@ -409,18 +409,18 @@ function PrescribedAtmosphere(grid, times=[zero(grid)];
         thermodynamics_parameters = AtmosphereThermodynamicsParameters(FT)
     end
 
-    atmosphere =  PrescribedAtmosphere(grid,
-                                       clock,
-                                       velocities,
-                                       pressure,
-                                       tracers,
-                                       freshwater_flux,
-                                       auxiliary_freshwater_flux,
-                                       downwelling_radiation,
-                                       thermodynamics_parameters,
-                                       times,
-                                       convert(FT, surface_layer_height),
-                                       convert(FT, boundary_layer_height))
+    atmosphere = PrescribedAtmosphere(grid,
+                                      clock,
+                                      velocities,
+                                      pressure,
+                                      tracers,
+                                      freshwater_flux,
+                                      auxiliary_freshwater_flux,
+                                      downwelling_radiation,
+                                      thermodynamics_parameters,
+                                      times,
+                                      convert(FT, surface_layer_height),
+                                      convert(FT, boundary_layer_height))
     update_state!(atmosphere)
 
     return atmosphere


### PR DESCRIPTION
Closes https://github.com/CliMA/ClimaOcean.jl/issues/646

This accounts for the case when `PrescribedAtmosphere` is instantiated with `start_date` and `end_date` which are not the default values with a dataset backend that only loads fields of certain timestamps in memory.

To illustrate this: consider
```julia
using ClimaOcean
using Oceananigans
using Oceananigans.OutputReaders: TimeInterpolator

arch = CPU()
jra55_dir = joinpath(homedir(), "JRA55_data")
dataset = MultiYearJRA55()
backend = JRA55NetCDFBackend(3)

start_date = DateTime(1993, 2, 1)
end_date = DateTime(1993, 3, 1)
atmosphere = JRA55PrescribedAtmosphere(arch; dir=jra55_dir, dataset, backend, include_rivers_and_icebergs=true, start_date, end_date)
```

If we want to index the fields at `start_date = 1993-01-01`:
```julia
julia> time_indexing = atmosphere.velocities.u.time_indexing
Oceananigans.OutputReaders.Cyclical{Float64}(2.43e6)

julia> times = atmosphere.velocities.u.times
1.107216e9:10800.0:1.1096352e9

julia> interpolator = TimeInterpolator(time_indexing, times, t)
TimeInterpolator{Float64, Int64, Int64, Int64}(1.0, 80, 81, 225)
```

The time index would be `interpolator.first_index = 80`

```julia
julia> atmosphere.velocities.u[:, :, :, interpolator.first_index]
646×326×1 OffsetArray(::Array{Float32, 3}, -2:643, -2:323, 1:1) with eltype Float32 with indices -2:643×-2:323×1:1:
[:, :, 1] =
 0.0  0.0  3.66142  -3.78156  -4.29006  -4.35326  -4.16169  -3.96527  -3.49554  …  3.78359  4.7718   5.60024  5.90582  5.4357   4.01959  -2.61346  0.0  0.0
 0.0  0.0  3.62934  -3.74948  -4.25832  -4.31347  -4.10957  -3.91254  -3.45453     3.84672  4.82815  5.64408  5.9392   5.45562  4.02397  -2.61784  0.0  0.0
 0.0  0.0  3.59725  -3.71739  -4.22658  -4.27367  -4.05745  -3.8598   -3.41351     3.90984  4.8845   5.68792  5.97258  5.47555  4.02835  -2.62222  0.0  0.0
 0.0  0.0  3.56517  -3.68531  -4.19484  -4.23388  -4.00532  -3.80707  -3.3725      3.97297  4.94085  5.73175  6.00596  5.49548  4.03273  -2.6266   0.0  0.0
 0.0  0.0  3.52627  -3.64641  -4.15734  -4.19042  -3.94746  -3.74745  -3.32636     4.03918  4.9977   5.77444  6.03528  5.50867  4.03065  -2.62451  0.0  0.0
 0.0  0.0  3.48738  -3.60752  -4.11984  -4.14696  -3.88961  -3.68783  -3.28021  …  4.10538  5.05455  5.81712  6.0646   5.52187  4.02856  -2.62243  0.0  0.0
 0.0  0.0  3.44848  -3.56862  -4.08234  -4.10351  -3.83175  -3.62821  -3.23407     4.17158  5.11141  5.8598   6.09391  5.53507  4.02648  -2.62034  0.0  0.0
 0.0  0.0  3.40959  -3.52973  -4.04483  -4.06005  -3.77389  -3.5686   -3.18793     4.23779  5.16826  5.90249  6.12323  5.54826  4.02439  -2.61826  0.0  0.0
 0.0  0.0  3.37069  -3.49083  -4.00733  -4.01659  -3.71603  -3.50898  -3.14179     4.30399  5.22511  5.94517  6.15255  5.56146  4.02231  -2.61617  0.0  0.0
 0.0  0.0  3.3318   -3.45194  -3.96983  -3.97313  -3.65817  -3.44936  -3.09379     4.37178  5.28196  5.98786  6.18187  5.57466  4.02022  -2.61409  0.0  0.0
 0.0  0.0  3.2929   -3.41304  -3.93233  -3.92968  -3.60031  -3.38779  -3.04116  …  4.44352  5.3391   6.03054  6.21118  5.58785  4.01814  -2.612    0.0  0.0
 0.0  0.0  3.254    -3.37414  -3.89483  -3.88622  -3.54246  -3.32231  -2.98853     4.51527  5.3968   6.07322  6.2405   5.60105  4.01605  -2.60992  0.0  0.0
 0.0  0.0  3.21511  -3.33525  -3.85733  -3.84057  -3.48154  -3.25684  -2.93589     4.58702  5.4545   6.11477  6.26502  5.61425  4.01397  -2.60783  0.0  0.0
 0.0  0.0  3.17621  -3.29635  -3.81983  -3.79491  -3.42063  -3.19136  -2.88326     4.65876  5.5122   6.15632  6.28954  5.62745  4.01188  -2.60575  0.0  0.0
 0.0  0.0  3.13732  -3.25746  -3.77676  -3.74926  -3.35972  -3.12589  -2.83063     4.73051  5.5699   6.19786  6.31406  5.63277  4.0098   -2.60366  0.0  0.0
 0.0  0.0  3.09842  -3.21856  -3.73369  -3.7036   -3.29881  -3.06041  -2.77458  …  4.8048   5.62761  6.23941  6.33858  5.6381   4.00771  -2.60158  0.0  0.0
 0.0  0.0  3.05953  -3.17967  -3.69063  -3.65795  -3.2379   -2.99494  -2.71596     4.881    5.68531  6.28096  6.3631   5.64343  4.00563  -2.59949  0.0  0.0
 0.0  0.0  3.01658  -3.13672  -3.64756  -3.6123   -3.17698  -2.9278   -2.65734     4.95719  5.74276  6.3225   6.38762  5.64876  3.99901  -2.59287  0.0  0.0
 0.0  0.0  2.97161  -3.09174  -3.60449  -3.56664  -3.11607  -2.85984  -2.59873     5.03339  5.80009  6.36405  6.41214  5.65409  3.99012  -2.58398  0.0  0.0
 0.0  0.0  2.92663  -3.04677  -3.56142  -3.52099  -3.05516  -2.79187  -2.54011     5.10959  5.85742  6.40559  6.43666  5.65942  3.98123  -2.57509  0.0  0.0
 ⋮                                       ⋮                                      ⋱                             ⋮                                         ⋮
 0.0  0.0  4.08428  -4.20442  -4.6893   -4.86047  -4.83027  -4.63563  -4.05235     2.90954  3.99979  4.98208  5.41316  5.11827  3.9362   -2.53006  0.0  0.0
 0.0  0.0  4.05937  -4.17951  -4.664    -4.83154  -4.79047  -4.59184  -4.01253     2.97141  4.05248  5.0264   5.45134  5.14369  3.9466   -2.54046  0.0  0.0
 0.0  0.0  4.03447  -4.15461  -4.63871  -4.79662  -4.74445  -4.54804  -3.97271     3.03328  4.10518  5.07073  5.48729  5.16911  3.957    -2.55086  0.0  0.0
 0.0  0.0  4.00956  -4.1297   -4.61341  -4.76171  -4.69843  -4.50424  -3.9329      3.09515  4.15787  5.11506  5.52323  5.19453  3.9674   -2.56126  0.0  0.0
 0.0  0.0  3.98226  -4.1024   -4.58812  -4.7268   -4.65241  -4.45922  -3.89308  …  3.15703  4.21161  5.1594   5.55918  5.21995  3.97579  -2.56965  0.0  0.0
 0.0  0.0  3.95018  -4.07032  -4.56282  -4.69189  -4.60639  -4.41176  -3.85326     3.2189   4.26744  5.20373  5.59513  5.24537  3.98017  -2.57403  0.0  0.0
 0.0  0.0  3.91809  -4.03823  -4.53753  -4.65697  -4.56037  -4.3643   -3.81373     3.2811   4.32327  5.24806  5.63107  5.27079  3.98455  -2.57841  0.0  0.0
 0.0  0.0  3.88601  -4.00615  -4.51224  -4.62206  -4.51435  -4.31683  -3.7746      3.34375  4.37909  5.29239  5.66702  5.29621  3.98893  -2.58279  0.0  0.0
 0.0  0.0  3.85393  -3.97406  -4.4805   -4.58715  -4.46833  -4.26937  -3.73546     3.4064   4.43492  5.33673  5.70296  5.31614  3.99331  -2.58717  0.0  0.0
 0.0  0.0  3.82184  -3.94198  -4.44876  -4.55224  -4.42231  -4.22191  -3.69632  …  3.46905  4.49075  5.38106  5.73891  5.33606  3.99769  -2.59156  0.0  0.0
 0.0  0.0  3.78976  -3.9099   -4.41702  -4.51244  -4.37019  -4.17445  -3.65719     3.53169  4.54657  5.42489  5.77229  5.35599  4.00207  -2.59594  0.0  0.0
 0.0  0.0  3.75767  -3.87781  -4.38528  -4.47265  -4.31806  -4.12348  -3.61805     3.59434  4.60275  5.46873  5.80567  5.37592  4.00645  -2.60032  0.0  0.0
 0.0  0.0  3.72559  -3.84573  -4.35354  -4.43285  -4.26594  -4.07074  -3.57757     3.65733  4.6591   5.51257  5.83905  5.39584  4.01083  -2.6047   0.0  0.0
 0.0  0.0  3.6935   -3.81364  -4.3218   -4.39306  -4.21382  -4.01801  -3.53656     3.72046  4.71545  5.55641  5.87243  5.41577  4.01521  -2.60908  0.0  0.0
 0.0  0.0  3.66142  -3.78156  -4.29006  -4.35326  -4.16169  -3.96527  -3.49554  …  3.78359  4.7718   5.60024  5.90582  5.4357   4.01959  -2.61346  0.0  0.0
 0.0  0.0  3.62934  -3.74948  -4.25832  -4.31347  -4.10957  -3.91254  -3.45453     3.84672  4.82815  5.64408  5.9392   5.45562  4.02397  -2.61784  0.0  0.0
 0.0  0.0  3.59725  -3.71739  -4.22658  -4.27367  -4.05745  -3.8598   -3.41351     3.90984  4.8845   5.68792  5.97258  5.47555  4.02835  -2.62222  0.0  0.0
 0.0  0.0  3.56517  -3.68531  -4.19484  -4.23388  -4.00532  -3.80707  -3.3725      3.97297  4.94085  5.73175  6.00596  5.49548  4.03273  -2.6266   0.0  0.0
 0.0  0.0  3.52627  -3.64641  -4.15734  -4.19042  -3.94746  -3.74745  -3.32636     4.03918  4.9977   5.77444  6.03528  5.50867  4.03065  -2.62451  0.0  0.0
 0.0  0.0  3.48738  -3.60752  -4.11984  -4.14696  -3.88961  -3.68783  -3.28021  …  4.10538  5.05455  5.81712  6.0646   5.52187  4.02856  -2.62243  0.0  0.0
```
Now we are able to do it.

@simone-silvestri @glwagner @navidcy @taimoorsohail 