### PR TITLE
Replace q_vap_saturation_from_density with q_vap_from_p_vap

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/interface_states.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/interface_states.jl
@@ -73,7 +73,7 @@ end
     ρₛ = convert(CT, ρₛ)
     phase = formulation.phase
     p★ = Thermodynamics.saturation_vapor_pressure(ℂₐ, Tₛ, phase)
-    q★ = Thermodynamics.q_vap_saturation_from_density(ℂₐ, Tₛ, ρₛ, p★)
+    q★ = Thermodynamics.q_vap_from_p_vap(ℂₐ, Tₛ, ρₛ, p★)
 
     # Compute saturation specific humidity according to Raoult's law
     χ_H₂O = compute_water_mole_fraction(formulation.water_mole_fraction, Sₛ)


### PR DESCRIPTION
q_vap_saturation_from_density is deprecated in Thermodynamics and is replaced by q_vap_from_p_vap