### PR TITLE
Add possibility to change top BC for the `sea_ice_simulation`

### DIFF
--- a/src/SeaIceSimulations.jl
+++ b/src/SeaIceSimulations.jl
@@ -32,6 +32,7 @@ function sea_ice_simulation(grid, ocean=nothing;
                             ice_density = 900, # kg m⁻³
                             dynamics = sea_ice_dynamics(grid, ocean),
                             bottom_heat_boundary_condition = nothing,
+                            top_heat_boundary_condition = nothing,
                             phase_transitions = PhaseTransitions(; ice_heat_capacity, ice_density),
                             conductivity = 2, # kg m s⁻³ K⁻¹
                             internal_heat_flux = ConductiveFlux(; conductivity))
@@ -40,8 +41,10 @@ function sea_ice_simulation(grid, ocean=nothing;
     # - bottom -> flux boundary condition
     # - top -> prescribed temperature boundary condition (calculated in the flux computation)
 
-    top_surface_temperature = Field{Center, Center, Nothing}(grid)
-    top_heat_boundary_condition = PrescribedTemperature(top_surface_temperature)
+    if isnothing(top_heat_boundary_condition)
+        top_surface_temperature = Field{Center, Center, Nothing}(grid)
+        top_heat_boundary_condition = PrescribedTemperature(top_surface_temperature)
+    end
 
     if isnothing(bottom_heat_boundary_condition)
         if isnothing(ocean)


### PR DESCRIPTION
this PR is motivated by the use of the `sea_ice_simulation` function in ClimaCoupler, where most likely we need to use a `MeltingConstrainedFluxBalance` top boundary condition since, at the moment, the flux solver does not compute the top temperature, so we can compute it inside ClimaSeaIce and use the previous top temperature to compute new fluxes.

cc @juliasloan25 