### PR TITLE
Allow Thermodynamics.jl version 0.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ Scratch = "1"
 SeawaterPolynomials = "0.3.5"
 StaticArrays = "1"
 Statistics = "1.9"
-Thermodynamics = "0.15"
+Thermodynamics = "0.14, 0.15"
 ZipFile = "0.10"
 julia = "1.10"
 


### PR DESCRIPTION
We would need to be able to use `Thermodynamics.jl` version 0.14.0 in ClimaCoupler because ClimaLand in stuck on version 0.14. Therefore, to be able to use ClimaOcean in ClimaCoupler, we need to allow `Thermodynamics.jl` version 0.14.0 in the compact.

The changes from 0.14 to 0.15 should not affect ClimaOcean.

cc @juliasloan25 