### PR TITLE
add depot to CI; use central queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_mem: 8G
   modules: climacommon/2025_07_30
 
@@ -9,6 +9,7 @@ env:
   OPENBLAS_NUM_THREADS: 1
   OMPI_MCA_opal_warn_on_missing_libcuda: 0
   JULIA_NUM_PRECOMPILE_TASKS: 8
+  JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default:"
 
 steps:
   - label: "initialize"
@@ -26,6 +27,8 @@ steps:
       - "echo '--- Initialize ClimaOcean test suite'"
       - "julia --project -e 'using CUDA; CUDA.precompile_runtime()'"
       - "julia --project -e 'using Pkg; Pkg.test()'"
+    concurrency: 1
+    concurrency_group: 'depot/climaocean-ci'
     agents:
       slurm_gpus: 1
       slurm_cpus_per_task: 8


### PR DESCRIPTION
This PR does 2 things:
- Switch the queue from `new-central` to `central`. Caltech's hpc cluster is switching to a new filesystem soon. As part of the update to the new system, we renamed the queue to central. It has to be updated here or the pipeline will stop working in December.
- Add a depot to the pipeline, which should help decrease initialization time (currently 45-50 minutes). The concurrency group limits one build to be able to initialize at a time, which avoids race conditions in accessing/modifying the cache.

If you ever need to clear the depot (e.g. if some packages get corrupted and can't be correctly accessed), you can go to the [Clear Depot pipeline](https://buildkite.com/clima/clear-depot), click "new build", and put your pipeline's name as the value for the environment variable `SLUG`, i.e. `slug=climaocean-ci` for this pipeline).

### Depot speedup
[First time using depot](https://buildkite.com/clima/climaocean-ci/builds/5054) (initializing full environment): 49 minutes
[Second time using depot](https://buildkite.com/clima/climaocean-ci/builds/5055) (cache hit): 22 minutes