### PR TITLE
Remove thermodynamic states

### DIFF
--- a/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/atmosphere_ocean_fluxes.jl
@@ -77,16 +77,16 @@ end
 
     # Build thermodynamic and dynamic states in the atmosphere and interface.
     # Notation:
-    #   ⋅ 𝒬 ≡ thermodynamic state vector
     #   ⋅ 𝒰 ≡ "dynamic" state vector (thermodynamics + reference height + velocity)
     ℂₐ = atmosphere_properties.thermodynamics_parameters
-    𝒬ₐ = thermodynamic_atmospheric_state = AtmosphericThermodynamics.PhaseEquil_pTq(ℂₐ, pₐ, Tₐ, qₐ)
     zₐ = atmosphere_properties.surface_layer_height # elevation of atmos variables relative to interface
 
     local_atmosphere_state = (z = zₐ,
                               u = uₐ,
                               v = vₐ,
-                              𝒬 = 𝒬ₐ,
+                              T = Tₐ,
+                              p = pₐ,
+                              q = qₐ,
                               h_bℓ = atmosphere_state.h_bℓ)
 
     local_interior_state = (u=uᵢ, v=vᵢ, T=Tᵢ, S=Sᵢ)
@@ -98,7 +98,7 @@ end
 
     # Estimate interface specific humidity using interior temperature
     q_formulation = interface_properties.specific_humidity_formulation
-    qₛ = surface_specific_humidity(q_formulation, ℂₐ, 𝒬ₐ, Tᵢ, Sᵢ)
+    qₛ = surface_specific_humidity(q_formulation, ℂₐ, Tₐ, pₐ, qₐ, Tᵢ, Sᵢ)
     initial_interface_state = InterfaceState(u★, u★, u★, uᵢ, vᵢ, Tᵢ, Sᵢ, qₛ)
 
     # Don't use convergence criteria in an inactive cell
@@ -144,9 +144,9 @@ end
     τx = ifelse(ΔU == 0, zero(grid), - u★^2 * Δu / ΔU)
     τy = ifelse(ΔU == 0, zero(grid), - u★^2 * Δv / ΔU)
 
-    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, 𝒬ₐ)
-    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ) # moist heat capacity
-    ℒv = AtmosphericThermodynamics.latent_heat_vapor(ℂₐ, 𝒬ₐ)
+    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, Tₐ, pₐ, qₐ)
+    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, qₐ) # moist heat capacity
+    ℒv = AtmosphericThermodynamics.latent_heat_vapor(ℂₐ, Tₐ)
     
 
     # Store fluxes

--- a/src/OceanSeaIceModels/InterfaceComputations/atmosphere_sea_ice_fluxes.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/atmosphere_sea_ice_fluxes.jl
@@ -93,16 +93,16 @@ end
 
     # Build thermodynamic and dynamic states in the atmosphere and interface.
     # Notation:
-    #   ⋅ 𝒬 ≡ thermodynamic state vector
     #   ⋅ 𝒰 ≡ "dynamic" state vector (thermodynamics + reference height + velocity)
     ℂₐ = atmosphere_properties.thermodynamics_parameters
-    𝒬ₐ = thermodynamic_atmospheric_state = AtmosphericThermodynamics.PhaseEquil_pTq(ℂₐ, pₐ, Tₐ, qₐ)
     zₐ = atmosphere_properties.surface_layer_height # elevation of atmos variables relative to interface
 
     local_atmosphere_state = (z = zₐ,
                               u = uₐ,
                               v = vₐ,
-                              𝒬 = 𝒬ₐ,
+                              T = Tₐ,
+                              p = pₐ,
+                              q = qₐ,
                               h_bℓ = atmosphere_state.h_bℓ)
 
     downwelling_radiation = (; Qs, Qℓ)
@@ -113,7 +113,7 @@ end
 
     # Estimate interface specific humidity using interior temperature
     q_formulation = interface_properties.specific_humidity_formulation
-    qₛ = surface_specific_humidity(q_formulation, ℂₐ, 𝒬ₐ, Tₛ, Sᵢ)
+    qₛ = surface_specific_humidity(q_formulation, ℂₐ, Tₐ, pₐ, qₐ, Tₛ, Sᵢ)
 
     # Guess
     Sₛ = zero(FT) # what should we use for interface salinity?
@@ -147,9 +147,9 @@ end
     τx = - u★^2 * Δu / ΔU
     τy = - u★^2 * Δv / ΔU
 
-    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, 𝒬ₐ)
-    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, 𝒬ₐ) # moist heat capacity
-    ℰs = AtmosphericThermodynamics.latent_heat_sublim(ℂₐ, 𝒬ₐ)
+    ρₐ = AtmosphericThermodynamics.air_density(ℂₐ, Tₐ, pₐ, qₐ)
+    cₚ = AtmosphericThermodynamics.cp_m(ℂₐ, qₐ) # moist heat capacity
+    ℰs = AtmosphericThermodynamics.latent_heat_sublim(ℂₐ, Tₐ)
 
     # Store fluxes
     Qv = interface_fluxes.latent_heat

--- a/src/OceanSeaIceModels/InterfaceComputations/compute_interface_state.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/compute_interface_state.jl
@@ -84,18 +84,18 @@ and interior properties `ℙₛ`, `ℙₐ`, and `ℙᵢ`.
                                        atmosphere_properties,
                                        interior_properties)
 
-    # Thermodynamic state
     FT = eltype(approximate_interface_state)
     ℂₐ = atmosphere_properties.thermodynamics_parameters
-    𝒬ₐ = atmosphere_state.𝒬
 
     # Recompute the saturation specific humidity at the interface based on the new temperature
     q_formulation = interface_properties.specific_humidity_formulation
     Sₛ = approximate_interface_state.S
-    qₛ = surface_specific_humidity(q_formulation, ℂₐ, 𝒬ₐ, Tₛ, Sₛ)
+    Tₐ = atmosphere_state.T
+    pₐ = atmosphere_state.p
+    qₐ = atmosphere_state.q
+    qₛ = surface_specific_humidity(q_formulation, ℂₐ, Tₐ, pₐ, qₐ, Tₛ, Sₛ)
 
     # Compute the specific humidity increment
-    qₐ = AtmosphericThermodynamics.vapor_specific_humidity(ℂₐ, 𝒬ₐ)
     Δq = qₐ - qₛ
 
     θₐ = surface_atmosphere_temperature(atmosphere_state, atmosphere_properties)

--- a/src/OceanSeaIceModels/InterfaceComputations/roughness_lengths.jl
+++ b/src/OceanSeaIceModels/InterfaceComputations/roughness_lengths.jl
@@ -144,11 +144,11 @@ function TemperatureDependentAirViscosity(FT = Oceananigans.defaults.FloatType;
                                             convert(FT, ℂ₃))
 end
 
-@inline compute_air_kinematic_viscosity(ν::Number, ℂ, 𝒬) = ν
+@inline compute_air_kinematic_viscosity(ν::Number, ℂ, T) = ν
 
 """ Calculate the air viscosity based on the temperature θ in Celsius. """
-@inline function compute_air_kinematic_viscosity(ν::TemperatureDependentAirViscosity, ℂ, 𝒬)
-    T₀ = AtmosphericThermodynamics.air_temperature(ℂ, 𝒬)
+@inline function compute_air_kinematic_viscosity(ν::TemperatureDependentAirViscosity, ℂ, T)
+    T₀ = T
     FT = eltype(ν.ℂ₀)
     T′ = convert(FT, T₀ - celsius_to_kelvin)
     return ν.ℂ₀ + ν.ℂ₁ * T′ + ν.ℂ₂ * T′^2 + ν.ℂ₃ * T′^3
@@ -160,8 +160,8 @@ end
 
 # Momentum roughness length should be different from scalar roughness length.
 # Temperature and water vapor can be considered the same (Edson et al. 2013)
-@inline function roughness_length(ℓ::MomentumRoughnessLength{FT}, u★, U, ℂₐ=nothing, 𝒬ₐ=nothing) where FT
-    ν = compute_air_kinematic_viscosity(ℓ.air_kinematic_viscosity, ℂₐ, 𝒬ₐ)
+@inline function roughness_length(ℓ::MomentumRoughnessLength{FT}, u★, U, ℂₐ=nothing, T=nothing) where FT
+    ν = compute_air_kinematic_viscosity(ℓ.air_kinematic_viscosity, ℂₐ, T)
     g = ℓ.gravitational_acceleration
     ℂg = gravity_wave_parameter(ℓ.wave_formulation, U)
     ℂν = ℓ.smooth_wall_parameter
@@ -197,9 +197,9 @@ ReynoldsScalingFunction(FT = Oceananigans.defaults.FloatType; A = 5.85e-5, b = 0
 @inline (s::ReynoldsScalingFunction)(R★, args...) = ifelse(R★ == 0, convert(eltype(R★), 0), s.A / R★ ^ s.b)
 
 # Edson 2013 formulation of scalar roughness length in terms of momentum roughness length ℓu
-@inline function roughness_length(ℓ::ScalarRoughnessLength{FT}, ℓu, u★, U, ℂ=nothing, 𝒬=nothing) where FT
+@inline function roughness_length(ℓ::ScalarRoughnessLength{FT}, ℓu, u★, U, ℂ=nothing, T=nothing) where FT
     # Roughness Reynolds number
-    ν = compute_air_kinematic_viscosity(ℓ.air_kinematic_viscosity, ℂ, 𝒬)
+    ν = compute_air_kinematic_viscosity(ℓ.air_kinematic_viscosity, ℂ, T)
     R★ = ℓu * u★ / ν
 
     # implementation of scalar roughness length
@@ -212,10 +212,10 @@ ReynoldsScalingFunction(FT = Oceananigans.defaults.FloatType; A = 5.85e-5, b = 0
 end
 
 # Convenience for users
-@inline function (ℓ::MomentumRoughnessLength{FT})(u★, U=nothing, ℂ=nothing, 𝒬=nothing) where FT
-    return roughness_length(ℓ, u★, ℂ, 𝒬)
+@inline function (ℓ::MomentumRoughnessLength{FT})(u★, U=nothing, ℂ=nothing, T=nothing) where FT
+    return roughness_length(ℓ, u★, ℂ, T)
 end
 
-@inline function (ℓ::ScalarRoughnessLength{FT})(u★, U=nothing, ℂ=nothing, 𝒬=nothing) where FT
-    return roughness_length(ℓ, u★, ℂ, 𝒬)
+@inline function (ℓ::ScalarRoughnessLength{FT})(u★, U=nothing, ℂ=nothing, T=nothing) where FT
+    return roughness_length(ℓ, u★, ℂ, T)
 end

--- a/test/test_surface_fluxes.jl
+++ b/test/test_surface_fluxes.jl
@@ -71,10 +71,9 @@ end
             atmosphere_ocean_interface_specific_humidity = FixedSpecificHumidity(qₐ)
 
             # Thermodynamic parameters of the atmosphere
-            𝒬ₐ = Thermodynamics.PhaseEquil_pTq(ℂₐ, pₐ, Tₐ, qₐ)
-            cp = Thermodynamics.cp_m(ℂₐ, 𝒬ₐ)
-            ρₐ = Thermodynamics.air_density(ℂₐ, 𝒬ₐ)
-            ℰv = Thermodynamics.latent_heat_vapor(ℂₐ, 𝒬ₐ)
+            cp = Thermodynamics.cp_m(ℂₐ, qₐ)
+            ρₐ = Thermodynamics.air_density(ℂₐ, Tₐ, pₐ, qₐ)
+            ℰv = Thermodynamics.latent_heat_vapor(ℂₐ, Tₐ)
 
             # No radiation equivalent
             radiation = Radiation(ocean_emissivity=0, ocean_albedo=1)
@@ -144,7 +143,7 @@ end
 
             interface_properties = interfaces.atmosphere_ocean_interface.properties
             q_formulation = interface_properties.specific_humidity_formulation
-            qₒ = surface_specific_humidity(q_formulation, ℂₐ, 𝒬ₐ, Tₒ, Sₒ)
+            qₒ = surface_specific_humidity(q_formulation, ℂₐ, Tₐ, pₐ, qₐ, Tₒ, Sₒ)
             g  = ocean.model.buoyancy.formulation.gravitational_acceleration
 
             # Differences!


### PR DESCRIPTION
This PR removes atmospheric thermodynamic states from ClimaOcean, in favor of the functional Thermodynamics.jl API. 

(We had discussed and decided to remove thermodynamic state constructors in favor of a more functional API for greater clarity and ease of debugging.)

It makes the minimal necessary changes to be compatible with future releases of Thermodynamics.jl. The thermodynamics calculations here could be further streamlined. 