### PR TITLE
fix longitude interfaces for GLORYS and `zf`

### DIFF
--- a/src/DataWrangling/GLORYS/GLORYS.jl
+++ b/src/DataWrangling/GLORYS/GLORYS.jl
@@ -129,7 +129,7 @@ end
 inpainted_metadata_path(metadata::GLORYSMetadata) = joinpath(metadata.dir, inpainted_metadata_filename(metadata))
 
 location(::GLORYSMetadata) = (Center, Center, Center)
-longitude_interfaces(::GLORYSMetadata) = (0, 360)
+longitude_interfaces(::GLORYSMetadata) = (-180, 180)
 latitude_interfaces(::GLORYSMetadata) = (-80, 90)
 
 function z_interfaces(metadata::GLORYSMetadata)
@@ -138,7 +138,7 @@ function z_interfaces(metadata::GLORYSMetadata)
     zc = - reverse(ds["depth"][:])
     close(ds)
     dz = zc[2] - zc[1]
-    zf = zc[1:end-1] .+ zc[2:end]
+    zf = (zc[1:end-1] .+ zc[2:end]) / 2
     push!(zf, 0)
     pushfirst!(zf, zf[1] - dz)
     return zf


### PR DESCRIPTION
Closes #742 . 

I also noticed that the calculation of `zf` was previously wrong.

Running the script shown in #742 gives the following:
<img width="2400" height="1800" alt="GLORYSDaily_noinpainting_bathymetrymask_updated" src="https://github.com/user-attachments/assets/2a4d929c-4742-4ec7-90fd-5311cf627b0e" />
which is what we expect