### PR TITLE
re-enable MPI tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,8 +150,6 @@ steps:
       slurm_mem: 10G
       slurm_cpus_per_task: 1
       slurm_ntasks: 4
-      modules: mpiwrapper/2024_05_27 climacommon/2026_02_18
-    soft_fail: true # remove this after library issues on central are fixed
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
MPI library issues are fixed on central now, so it's been added back into climacommon, and we can remove the soft fail from MPI runs in buildkite.

Reverts soft-fail change from #770 