### PR TITLE
use topology from intermediate grid in regrid_bathymetry

### DIFF
--- a/src/Bathymetry/regrid_bathymetry.jl
+++ b/src/Bathymetry/regrid_bathymetry.jl
@@ -197,7 +197,8 @@ function interpolate_bathymetry_in_passes(native_z, target_grid;
     Nφ = Int[Nφ..., Nφt]
 
     old_z  = native_z
-    TX, TY = topology(target_grid)
+
+    TX, TY, _ = topology(native_z.grid)
 
     Hx, Hy, Hz = Oceananigans.halo_size(native_z.grid)
 


### PR DESCRIPTION
When we update to Oceananigans v0.106.6, we start getting an error in CI (e.g. see [here](https://buildkite.com/clima/climaocean-ci/builds/5954#019e2d09-2e1e-42a8-9804-21c57d216487)), as a result of stricter validation from https://github.com/CliMA/Oceananigans.jl/pull/5489.

This PR takes the topology from the intermediate grid instead of the target grid to avoid this boundary validation error.
