### PR TITLE
Skip ECCO download when files exist

### DIFF
--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -284,6 +284,10 @@ function metadata_url(m::Metadata{<:ECCO4Monthly})
 end
 
 function download_dataset(metadata::ECCOMetadata)
+    # if all files are already downloaded, skip
+    @info "ECCO Metadata:" metadata
+    all(isfile(metadata_path(m)) for m in metadata) && return nothing
+
     username = get(ENV, "ECCO_USERNAME", nothing)
     password = get(ENV, "ECCO_WEBDAV_PASSWORD", nothing)
     dir = metadata.dir

--- a/src/DataWrangling/ECCO/ECCO.jl
+++ b/src/DataWrangling/ECCO/ECCO.jl
@@ -285,7 +285,6 @@ end
 
 function download_dataset(metadata::ECCOMetadata)
     # if all files are already downloaded, skip
-    @info "ECCO Metadata:" metadata
     all(isfile(metadata_path(m)) for m in metadata) && return nothing
 
     username = get(ENV, "ECCO_USERNAME", nothing)


### PR DESCRIPTION
This change allows us to use data artifacts the ClimaCoupler; without it, `download_dataset` always tries to open a temporary directory, even when the data already exists. Since buildkite doesn't have permissions to access the folder where we keep our artifacts, this was [causing an error](https://buildkite.com/clima/climacoupler-ci/builds/8918/list?sid=019e47e3-09b6-44c7-9032-6c2fbd6d57b1&tab=output). With this change, the error [is fixed](https://buildkite.com/clima/climacoupler-ci/builds/8913/list?sid=019e4760-1998-4643-b0d7-bd78a431c9d5&tab=output).